### PR TITLE
feature: 메일 가져온 갯수만큼 receive 하도록 수정

### DIFF
--- a/batch/src/main/kotlin/com/nexters/newsletterfeeder/service/MailReader.kt
+++ b/batch/src/main/kotlin/com/nexters/newsletterfeeder/service/MailReader.kt
@@ -12,25 +12,35 @@ import org.springframework.stereotype.Service
 @Service
 class MailReader(
     val mailMessageSource: MessageSource<*>,
-    val mailChannel: MessageChannel
+    val mailChannel: MessageChannel,
 ) {
     fun read() {
         try {
-            LOGGER.info("Checking for new emails...")
+            LOGGER.info("=== 메일 읽기 시작 (최대 10개 ) ===")
+            var count = 0
+            val maxFetchSize = 10 // MailChannelConfig의 DEFAULT_FETCH_MAIL_SIZE와 동일
 
-            // 메일 메시지 소스에서 메시지를 받아옴
-            val message = mailMessageSource.receive()
+            repeat(maxFetchSize) { index ->
+                val message = mailMessageSource.receive()
 
-            if (message != null) {
-                LOGGER.info("Found new email message")
-                // 메일 채널로 메시지 전송
+                if (message != null) {
+                    count++
+                    LOGGER.info("[$count] 메일 처리 중...")
 
-                mailChannel.send(GenericMessage(EmailMessage.fromMimeMessage(message.payload as MimeMessage), message.headers))
-            } else {
-                LOGGER.info("No new emails found")
+                    val emailMessage = EmailMessage.fromMimeMessage(message.payload as MimeMessage)
+                    LOGGER.info("[$count] 제목: ${emailMessage.subject}")
+
+                    mailChannel.send(GenericMessage(emailMessage, message.headers))
+                } else {
+                    LOGGER.info("${index + 1}번째 시도에서 메일 없음 - 중단")
+                    return@repeat
+                }
             }
+
+            LOGGER.info("=== 총 ${count}개 메일 처리 완료 ===")
+
         } catch (e: Exception) {
-            LOGGER.error("Error reading emails", e)
+            LOGGER.error("메일 읽기 중 오류 발생", e)
         }
     }
 


### PR DESCRIPTION
## 내용
- batch size 만큼 mailMessageSource.receive 하도록 변경


## 논의사항 
- pop3 메일 수신 방법이 중복 제거가 안됨. 
- 몇개의 메일을 수신해서 메타 데이터로 저장할지?
- 공용메일에 들어온 모든 메일을 수신하게 되는데 구독하지 않은 뉴스레터도 수신됨 (필터링 로직 필요)