### PR TITLE
KotlinWeeklyParser 추가

### DIFF
--- a/batch/src/main/kotlin/com/nexters/newsletterfeeder/parser/KotlinWeeklyParser.kt
+++ b/batch/src/main/kotlin/com/nexters/newsletterfeeder/parser/KotlinWeeklyParser.kt
@@ -1,0 +1,135 @@
+package com.nexters.newsletterfeeder.parser
+
+class KotlinWeeklyParser : MailParser {
+    override fun isTarget(sender: String): Boolean =
+        sender.contains(NEWSLETTER_NAME, ignoreCase = true) ||
+            sender.contains(NEWSLETTER_MAIL_ADDRESS, ignoreCase = true)
+
+    override fun parse(content: String): List<MailContent> {
+        val plainText = extractPlainTextContent(content) ?: return emptyList()
+        val normalized = plainText.normalizeSoftBreaks()
+        val issueInfo = extractIssueInfo(normalized)
+        return parseSections(normalized, issueInfo)
+    }
+
+    private fun extractPlainTextContent(content: String): String? {
+        val plainTextStartMarker = "Content-Type: text/plain;"
+
+        val startIndex = content.indexOf(plainTextStartMarker)
+        if (startIndex == -1) return content
+
+        var contentStartIndex = content.indexOf("\n\n", startIndex)
+        if (contentStartIndex == -1) contentStartIndex = content.indexOf("\r\n\r\n", startIndex)
+        if (contentStartIndex == -1) return content
+
+        return content.substring(contentStartIndex + 2)
+    }
+
+    private data class IssueInfo(
+        val number: String,
+        val date: String
+    )
+
+    private fun extractIssueInfo(content: String): IssueInfo {
+        val issueMatch = ISSUE_NUMBER_REGEX.find(content)
+        val issueNumber = issueMatch?.groupValues?.get(1) ?: "Unknown"
+
+        val dateMatch = ISSUE_DATE_REGEX.find(content)
+        val issueDate = dateMatch?.value ?: "Unknown date"
+
+        return IssueInfo(issueNumber, issueDate)
+    }
+
+    private fun parseSections(
+        content: String,
+        issueInfo: IssueInfo
+    ): List<MailContent> {
+        val headerPositions =
+            Section.entries
+                .associateWith { header -> content.indexOf("\n${header.label}\n") }
+                .filterValues { it >= 0 }
+                .toList()
+                .sortedBy { it.second }
+
+        if (headerPositions.isEmpty()) {
+            return listOf()
+        }
+
+        return headerPositions
+            .filter { it.first != Section.CONTRIBUTE }
+            .flatMapIndexed { idx, (section, start) ->
+                val end = headerPositions.getOrNull(idx + 1)?.second ?: content.length
+                val sectionContent = content.substring(start, end)
+                parseSection(section, sectionContent, issueInfo)
+            }
+    }
+
+    private fun parseSection(
+        section: Section,
+        rawSectionText: String,
+        issueInfo: IssueInfo
+    ): List<MailContent> {
+        val lines = rawSectionText.lines()
+        val seenTitles = mutableSetOf<String>()
+        val results = mutableListOf<MailContent>()
+
+        for (index in lines.indices) {
+            val match = TITLE_LINK_REGEX.find(lines[index]) ?: continue
+            val title = match.groupValues[1].trim()
+            val url = match.groupValues[2].trim().cleanUrl()
+            if (title.matches(DOMAIN_ONLY_REGEX) || !seenTitles.add(title)) continue
+
+            val description = collectDescription(lines, index + 1)
+            val contentText = "[${section.label}] Issue #${issueInfo.number} (${issueInfo.date}): $description"
+            results += MailContent(title = title, content = contentText, link = url, section = section.label)
+        }
+        return results
+    }
+
+    private fun collectDescription(
+        lines: List<String>,
+        from: Int
+    ): String =
+        lines
+            .drop(from)
+            .map { it.trim() }
+            .takeWhile { !isBoundaryLine(it) }
+            .joinToString(" ")
+
+    private fun isBoundaryLine(line: String): Boolean =
+        line.isBlank() ||
+            TITLE_LINK_REGEX.containsMatchIn(line) ||
+            Section.fromLabel(line) != null ||
+            line.matches(DOMAIN_ONLY_REGEX)
+
+    private fun String.cleanUrl(): String = replace("\n", "").replace("\r", "").replace(" ", "")
+
+    private fun String.normalizeSoftBreaks(): String = replace("=\r\n", "=").replace("=\n", "=").replace("=\r", "=")
+
+    companion object {
+        private val ISSUE_NUMBER_REGEX = Regex("ISSUE #(\\d+)")
+        private val ISSUE_DATE_REGEX = Regex("(\\d+)[a-z]{2} of [A-Za-z]+ \\d{4}")
+        private val TITLE_LINK_REGEX = Regex("(.*?)\\s*\\(\\s*(https?://[^)]+)\\)\\s*$")
+        private val DOMAIN_ONLY_REGEX = Regex("^[a-z0-9.-]+\\.[a-z]{2,}$")
+
+        private const val NEWSLETTER_NAME = "Kotlin Weekly"
+        private const val NEWSLETTER_MAIL_ADDRESS = "kotlinweekly.net"
+    }
+
+    private enum class Section(
+        val label: String
+    ) {
+        ANNOUNCEMENTS("Announcements"),
+        ARTICLES("Articles"),
+        SPONSORED("Sponsored"),
+        ANDROID("Android"),
+        PODCAST("Podcast"),
+        CONFERENCES("Conferences"),
+        LIBRARIES("Libraries"),
+        CONTRIBUTE("Contribute");
+
+        companion object {
+            fun fromLabel(label: String) = entries.firstOrNull { it.label == label }
+        }
+    }
+}

--- a/batch/src/main/kotlin/com/nexters/newsletterfeeder/parser/MailContent.kt
+++ b/batch/src/main/kotlin/com/nexters/newsletterfeeder/parser/MailContent.kt
@@ -1,0 +1,8 @@
+package com.nexters.newsletterfeeder.parser
+
+data class MailContent(
+    val title: String,
+    val content: String,
+    val link: String,
+    val section: String? = null,
+)

--- a/batch/src/main/kotlin/com/nexters/newsletterfeeder/parser/MailParser.kt
+++ b/batch/src/main/kotlin/com/nexters/newsletterfeeder/parser/MailParser.kt
@@ -1,0 +1,7 @@
+package com.nexters.newsletterfeeder.parser
+
+interface MailParser {
+    fun isTarget(sender: String): Boolean
+
+    fun parse(content: String): List<MailContent>
+}

--- a/batch/src/test/kotlin/com/nexters/newsletterfeeder/parser/KotlinWeeklyParserTest.kt
+++ b/batch/src/test/kotlin/com/nexters/newsletterfeeder/parser/KotlinWeeklyParserTest.kt
@@ -1,0 +1,297 @@
+package com.nexters.newsletterfeeder.parser
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class KotlinWeeklyParserTest {
+    private val sut = KotlinWeeklyParser()
+
+    @Test
+    fun `isTarget should return true for Kotlin Weekly emails`() {
+        assertTrue(sut.isTarget("Kotlin Weekly <mailinglist@kotlinweekly.net>"))
+        assertTrue(sut.isTarget("newsletter@kotlinweekly.net"))
+        assertTrue(sut.isTarget("Kotlin Weekly"))
+    }
+
+    @Test
+    fun `isTarget should return false for non-Kotlin Weekly emails`() {
+        assertFalse(sut.isTarget("Some Other Newsletter <info@example.com>"))
+        assertFalse(sut.isTarget("random@example.com"))
+    }
+
+    @Test
+    fun `parse should extract articles from Kotlin Weekly newsletter`() {
+        val sampleEmail =
+            """
+            Content-Type: text/plain; charset="utf-8"; format="fixed"
+            Content-Transfer-Encoding: quoted-printable
+
+            ** ISSUE #468
+            ------------------------------------------------------------
+            20th of July 2025
+
+            Announcements
+            Develocity Plugin for IntelliJ (https://plugins.jetbrains.com/plugin/27471-=
+            develocity/)
+            The Gradle team has released the Develocity plugin for IntelliJ IDEA and An=
+            droid Studio, which provides live build time information directly in the ID=
+            E. Check it out!
+            plugins.jetbrains.com
+
+            Building Better Agents: What=E2=80=99s New in Koog 0.3.0 (https://blog.jetb=
+            rains.com/ai/2025/07/building-better-agents-what-s-new-in-koog-0-3-0/)
+            JetBrains has just released Koog 0.3.0, which comes with many updates that =
+            make building, running, and managing intelligent agents easier.
+            blog.jetbrains.com
+
+            Breaking to Build: Fuzzing the Kotlin Compiler (https://blog.jetbrains.com/=
+            research/2025/07/fuzzing-the-kotlin-compiler/)
+            Katie Fraser outlines JetBrains=E2=80=99 evolutionary generative fuzzing, d=
+            eveloped with TU Delft, to expose and fix subtle bugs in the Kotlin compile=
+            r, including K2 regressions.
+            blog.jetbrains.com
+
+            Anvil Moves to Maintenance Mode (https://github.com/square/anvil/issues/114=
+            9)
+            Anvil is moving into mainteinance mode and endorsing Metro as its successor=
+            . Read more about it to know what this means for you, if you are an Anvil u=
+            ser.
+            github.com
+
+            Ktor 3.2.2 Is Now Available (https://blog.jetbrains.com/kotlin/2025/07/ktor=
+            -3-2-0-is-now-available-2/)
+            The Ktor 3.2.2 patch release brings a critical fix for Android D8 compatibi=
+            lity, along with some minor enhancements and bug fixes. Check more of the g=
+            oodies included here.
+            blog.jetbrains.com
+
+            Articles
+            Flow Marbles (https://terrakok.github.io/FlowMarbles/)
+            The following website provides interactive diagrams of Kotlinx.coroutines F=
+            low, a nice way to visualize them.
+            terrakok.github.io
+
+            How to turn callback functions into suspend functions or Flow (https://kt.a=
+            cademy/article/interop-callbacks-to-coroutines)
+            Marcin Moskala explains how to convert callback-based APIs into suspend fun=
+            ctions or Flows to make them coroutine-friendly and idiomatic in Kotlin.
+            kt.academy
+
+            Exploring PausableComposition internals in Jetpack Compose (https://blog.sh=
+            reyaspatil.dev/exploring-pausablecomposition-internals-in-jetpack-compose)
+            Elian van Cutsem explores Kotlin DSLs as an elegant alternative to annotati=
+            on processing, enabling compile-time code generation with improved readabil=
+            ity and reduced complexity.
+            blog.shreyaspatil.dev
+
+            Contract Test (https://zalas.pl/contract-test/)
+            Jakub Zalas presents the Contract Test pattern, adapted from xUnit Test Pat=
+            terns, as a structured way to verify implementations of abstractions that i=
+            nterface with external systems.
+            zalas.pl
+
+            Kotlin Clean Code Rearranger (https://plugins.jetbrains.com/plugin/27537-ko=
+            tlin-clean-code-rearranger)
+            Marco Plasmati has published an Intellij IDEA plugin tha rearranges Kotlin =
+            functions according to the Step-Down rule.
+            plugins.jetbrains.com
+
+            Sponsored
+            Product for Engineers newsletter ( https://newsletter.posthog.com?r=3D5yje7=
+            p)
+            Learn to build better products, not just better code. Learn how to talk to =
+            users, build features they love, and find product market fit. Subscribe for=
+             free.
+            newsletter.posthog.com
+
+            Android
+            How to Input Unicode Characters in Maestro Android Tests: A Complete Workar=
+            ound Guide (https://blog.droidchef.dev/how-to-input-unicode-characters-in-m=
+            aestro-android-tests-a-complete-workaround-guide/)
+            Ishan Khanna shares a complete workaround to enable Unicode input in Maestr=
+            o Android tests using ADB Keyboard, a local HTTP server, and JavaScript int=
+            egration.
+            blog.droidchef.dev
+
+            Podcast
+            Android MCP SDK with Jason Pearson (https://thebakery.dev/99/)
+            Nico Corti speaks with Jason Pearson about the Android MCP SDK, a new libra=
+            ry that allow Android developers to build apps that can communicate with AI=
+            models more effectively.
+            thebakery.dev
+
+            Conferences
+            Unlock Kotlin Flow: Free Live Webinar =E2=80=93 July 22 (https://webinar.kt=
+            .academy/mastering-kotlin-flow-07)
+            Go beyond basics! Learn how Kotlin Flow handles values, errors & completion=
+             downstream and how requests travel upstream. Understand core operators & c=
+            oncurrency syncing. 2 time zones, live Q&A.
+            webinar.kt.academy (https://webinar.kt.academy/mastering-kotlin-flow-07)
+
+            Libraries
+            Liquid Glass (https://github.com/Kyant0/AndroidLiquidGlass)
+            Library providing Apple's Liquid Glass effect for Android Jetpack Compose.
+            github.com
+
+            ScribeSwan (https://gitlab.com/islandoftex/libraries/scribeswan/)
+            ScribeSwan is a Kotlin Multiplatform library that provides a DSL (domain-sp=
+            ecific language) for creating manpages in the troff format used by the Unix=
+             man command.
+            gitlab.com
+            """.trimIndent()
+
+        // when
+        val result = sut.parse(sampleEmail)
+
+        // then
+        assertEquals(16, result.size, "Expected 16 articles, but got ${result.size}")
+
+        // Verify articles irrespective of order
+        verifyArticle(
+            result[0],
+            "Develocity Plugin for IntelliJ",
+            "https://plugins.jetbrains.com/plugin/27471-=develocity/",
+            "Announcements",
+            "The Gradle team has released"
+        )
+
+        verifyArticle(
+            result[1],
+            "Building Better Agents: What=E2=80=99s New in Koog 0.3.0",
+            "https://blog.jetb=rains.com/ai/2025/07/building-better-agents-what-s-new-in-koog-0-3-0/",
+            "Announcements",
+            "JetBrains has just released Koog 0.3.0"
+        )
+
+        verifyArticle(
+            result[2],
+            "Breaking to Build: Fuzzing the Kotlin Compiler",
+            "https://blog.jetbrains.com/=research/2025/07/fuzzing-the-kotlin-compiler/",
+            "Announcements",
+            "evolutionary generative fuzzing"
+        )
+
+        verifyArticle(
+            result[3],
+            "Anvil Moves to Maintenance Mode",
+            "https://github.com/square/anvil/issues/114=9",
+            "Announcements",
+            "mainteinance mode"
+        )
+
+        verifyArticle(
+            result[4],
+            "Ktor 3.2.2 Is Now Available",
+            "https://blog.jetbrains.com/kotlin/2025/07/ktor=-3-2-0-is-now-available-2/",
+            "Announcements",
+            "critical fix for Android D8"
+        )
+
+        verifyArticle(
+            result[5],
+            "Flow Marbles",
+            "https://terrakok.github.io/FlowMarbles/",
+            "Articles",
+            "interactive diagrams"
+        )
+
+        verifyArticle(
+            result[6],
+            "How to turn callback functions into suspend functions or Flow",
+            "https://kt.a=cademy/article/interop-callbacks-to-coroutines",
+            "Articles",
+            "convert callback-based APIs"
+        )
+
+        verifyArticle(
+            result[7],
+            "Exploring PausableComposition internals in Jetpack Compose",
+            "https://blog.sh=reyaspatil.dev/exploring-pausablecomposition-internals-in-jetpack-compose",
+            "Articles",
+            "Kotlin DSLs"
+        )
+
+        verifyArticle(
+            result[8],
+            "Contract Test",
+            "https://zalas.pl/contract-test/",
+            "Articles",
+            "Contract Test pattern"
+        )
+
+        verifyArticle(
+            result[9],
+            "Kotlin Clean Code Rearranger",
+            "https://plugins.jetbrains.com/plugin/27537-ko=tlin-clean-code-rearranger",
+            "Articles",
+            "an Intellij IDEA plugin tha rearranges Kotlin"
+        )
+
+        verifyArticle(
+            result[10],
+            "Product for Engineers newsletter",
+            "https://newsletter.posthog.com?r=3D5yje7=p",
+            "Sponsored",
+            "build better products"
+        )
+
+        verifyArticle(
+            result[11],
+            "How to Input Unicode Characters in Maestro Android Tests",
+            "https://blog.droidchef.dev/how-to-input-unicode-characters-in-m=aestro-android-tests-a-complete-workaround-guide/",
+            "Android",
+            "complete workaround"
+        )
+
+        verifyArticle(
+            result[12],
+            "Android MCP SDK with Jason Pearson",
+            "https://thebakery.dev/99/",
+            "Podcast",
+            "Nico Corti speaks with Jason Pearson"
+        )
+
+        verifyArticle(
+            result[13],
+            "Unlock Kotlin Flow: Free Live Webinar",
+            "https://webinar.kt=.academy/mastering-kotlin-flow-07",
+            "Conferences",
+            "Go beyond basics"
+        )
+
+        verifyArticle(
+            result[14],
+            "Liquid Glass",
+            "https://github.com/Kyant0/AndroidLiquidGlass",
+            "Libraries",
+            "Apple's Liquid Glass effect"
+        )
+
+        verifyArticle(
+            result[15],
+            "ScribeSwan",
+            "https://gitlab.com/islandoftex/libraries/scribeswan/",
+            "Libraries",
+            "DSL (domain-sp=ecific language) for creating manpages"
+        )
+    }
+
+    private fun verifyArticle(
+        article: MailContent,
+        expectedTitle: String,
+        expectedLink: String,
+        expectedSection: String,
+        expectedContentSnippet: String
+    ) {
+        assertNotNull(article, "Article with title containing '$expectedTitle' not found")
+        assertEquals(expectedLink, article?.link)
+        assertEquals(expectedSection, article?.section)
+        assertTrue(
+            article?.content?.contains(expectedContentSnippet) ?: false,
+            "Article content should contain snippet '$expectedContentSnippet'"
+        )
+    }
+}


### PR DESCRIPTION
어제 잠깐 깨서 구상을 해봄

이런 패턴 인식은 역시 AI가 젤 잘하는듯
테스트를 미리 짜놓고 아래 프롬프트 같이 넣어서 생성하면 잘 생성하는듯

```
이 "parse should extract articles from Kotlin Weekly newsletter" 테스트에서 아래 목록의 컨텐츠 리스트를 반환해야해. 테스트에서 입력에 사용하는 텍스트를 바꾸거나 하면 안돼.

절대 로직에 아래 값들을 하드코딩하지 않고 반환하게 로직을 짜야해.

- Develocity Plugin for IntelliJ
- Building Better Agents: What’s New in Koog 0.3.0
- Breaking to Build: Fuzzing the Kotlin Compiler
- Anvil Moves to Maintenance Mode
- Ktor 3.2.2 Is Now Available
- Flow Marbles
- How to turn callback functions into suspend functions or Flow
- Exploring PausableComposition internals in Jetpack Compose
- Contract Test
- Kotlin Clean Code Rearranger
- Product for Engineers newsletter
- How to Input Unicode Characters in Maestro Android Tests: A Complete Workaround Guide
- Android MCP SDK with Jason Pearson
- Unlock Kotlin Flow: Free Live Webinar – July 22
- Liquid Glass
- ScribeSwan
```