### PR TITLE
newsletterSource가 존재하지 않으면 RssProcessStatus 제거

### DIFF
--- a/external/src/main/kotlin/com/nexters/external/service/RssAiProcessingService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/RssAiProcessingService.kt
@@ -80,10 +80,13 @@ class RssAiProcessingService(
 
     private fun processRssItem(status: RssProcessingStatus) {
         // NewsletterSource 조회
-        val newsletterSource =
-            newsletterSourceRepository
-                .findById(status.newsletterSourceId)
-                .orElseThrow { NoSuchElementException("NewsletterSource not found: ${status.newsletterSourceId}") }
+        val newsletterSource = newsletterSourceRepository.findById(status.newsletterSourceId).orElse(null)
+
+        if (newsletterSource == null) {
+            logger.warn("NewsletterSource not found for ID: ${status.newsletterSourceId}, removing RssProcessingStatus")
+            rssProcessingStatusRepository.delete(status)
+            return
+        }
 
         // RSS Item URL 가져오기
         val originalUrl = newsletterSource.headers["RSS-Item-URL"] ?: ""


### PR DESCRIPTION
수동으로 지우거나 데이터에 이상이 생기면 NewsletterSource가 존재하지 않을 수 있음.
존재하지 않으면 복구할 방법이 없으니 일단 제거