### PR TITLE
ContentProvider 매칭 로직 추가, 언어 라벨 표시

### DIFF
--- a/admin/src/main/kotlin/com/nexters/admin/controller/NewsletterSourceAdminController.kt
+++ b/admin/src/main/kotlin/com/nexters/admin/controller/NewsletterSourceAdminController.kt
@@ -5,6 +5,7 @@ import com.nexters.external.entity.NewsletterSource
 import com.nexters.external.repository.ContentRepository
 import com.nexters.external.repository.NewsletterSourceRepository
 import com.nexters.external.repository.SummaryRepository
+import com.nexters.external.service.ContentProviderService
 import com.nexters.external.service.ExposureContentService
 import com.nexters.external.service.KeywordService
 import com.nexters.newsletter.parser.MailContent
@@ -42,7 +43,8 @@ class NewsletterSourceApiController(
     private val summaryRepository: SummaryRepository,
     private val keywordService: KeywordService,
     private val exposureContentService: ExposureContentService,
-    private val newsletterProcessingService: NewsletterProcessingService
+    private val newsletterProcessingService: NewsletterProcessingService,
+    private val contentProviderService: ContentProviderService
 ) {
     private val mailParserFactory = MailParserFactory()
 
@@ -130,6 +132,8 @@ class NewsletterSourceApiController(
         // RSS 소스의 경우 헤더에서 원본 URL 추출, 없으면 요청된 URL 사용
         val finalOriginalUrl = newsletterSource.headers["RSS-Item-URL"] ?: request.originalUrl
 
+        val contentProvider = contentProviderService.findByName(request.newsletterName)
+
         val newContent =
             Content(
                 newsletterSourceId = newsletterSource.id,
@@ -138,6 +142,7 @@ class NewsletterSourceApiController(
                 newsletterName = request.newsletterName,
                 originalUrl = finalOriginalUrl,
                 publishedAt = request.publishedAt,
+                contentProvider = contentProvider,
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now()
             )
@@ -242,6 +247,8 @@ class NewsletterSourceApiController(
         // RSS 소스의 경우 헤더에서 원본 URL 추출, 없으면 요청된 URL 사용
         val finalOriginalUrl = newsletterSource.headers["RSS-Item-URL"] ?: request.originalUrl
 
+        val contentProvider = contentProviderService.findByName(request.newsletterName)
+
         val newContent =
             Content(
                 newsletterSourceId = newsletterSource.id,
@@ -250,6 +257,7 @@ class NewsletterSourceApiController(
                 newsletterName = request.newsletterName,
                 originalUrl = finalOriginalUrl,
                 publishedAt = request.publishedAt,
+                contentProvider = contentProvider,
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now()
             )

--- a/api/src/main/kotlin/com/nexters/api/controller/NewsletterApiController.kt
+++ b/api/src/main/kotlin/com/nexters/api/controller/NewsletterApiController.kt
@@ -43,6 +43,7 @@ class NewsletterApiController(
                         summary = it.summaryContent,
                         contentUrl = it.content.originalUrl,
                         newsletterName = it.content.newsletterName,
+                        language = ContentViewApiResponse.Language.fromString(it.content.contentProvider?.language),
                     )
                 },
         )

--- a/api/src/main/kotlin/com/nexters/api/dto/ContentViewApiResponse.kt
+++ b/api/src/main/kotlin/com/nexters/api/dto/ContentViewApiResponse.kt
@@ -13,11 +13,20 @@ data class ContentViewApiResponse(
         val summary: String,
         val contentUrl: String,
         val newsletterName: String,
-        val language: Language = Language.ENGLISH,
+        val language: Language,
     )
 
     enum class Language {
         ENGLISH,
         KOREAN,
+        ;
+
+        companion object {
+            fun fromString(language: String?): Language =
+                when (language?.lowercase()) {
+                    "ko", "korean", "한국어" -> KOREAN
+                    else -> ENGLISH
+                }
+        }
     }
 }

--- a/external/src/main/kotlin/com/nexters/external/entity/Content.kt
+++ b/external/src/main/kotlin/com/nexters/external/entity/Content.kt
@@ -1,5 +1,6 @@
 package com.nexters.external.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -9,6 +10,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.JoinTable
 import jakarta.persistence.ManyToMany
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -31,6 +33,10 @@ class Content(
     val originalUrl: String,
     @Column(nullable = true, name = "published_at")
     val publishedAt: LocalDate,
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "content_provider_id")
+    @JsonIgnoreProperties("categories")
+    var contentProvider: ContentProvider? = null,
     @Column(nullable = false, name = "created_at")
     val createdAt: LocalDateTime = LocalDateTime.now(),
     @Column(nullable = false, name = "updated_at")

--- a/external/src/main/kotlin/com/nexters/external/repository/ContentProviderRepository.kt
+++ b/external/src/main/kotlin/com/nexters/external/repository/ContentProviderRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface ContentProviderRepository : JpaRepository<ContentProvider, Long>
+interface ContentProviderRepository : JpaRepository<ContentProvider, Long> {
+    fun findByName(name: String): ContentProvider?
+}

--- a/external/src/main/kotlin/com/nexters/external/service/ContentProviderService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/ContentProviderService.kt
@@ -1,0 +1,12 @@
+package com.nexters.external.service
+
+import com.nexters.external.entity.ContentProvider
+import com.nexters.external.repository.ContentProviderRepository
+import org.springframework.stereotype.Service
+
+@Service
+class ContentProviderService(
+    private val contentProviderRepository: ContentProviderRepository
+) {
+    fun findByName(name: String): ContentProvider? = contentProviderRepository.findByName(name)
+}

--- a/external/src/main/resources/schema.sql
+++ b/external/src/main/resources/schema.sql
@@ -56,9 +56,10 @@ CREATE TABLE IF NOT EXISTS contents
     content              TEXT         NOT NULL,
     newsletter_name      VARCHAR(255) NOT NULL,
     original_url         VARCHAR(255) NOT NULL,
-    published_at         DATE NOT NULL,
+    published_at         DATE         NOT NULL,
     created_at           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    content_provider_id  BIGINT
 );
 
 -- Summaries table
@@ -165,12 +166,12 @@ CREATE INDEX IF NOT EXISTS idx_fcm_token ON fcm_tokens (fcm_token);
 -- Content providers table
 CREATE TABLE IF NOT EXISTS content_provider
 (
-    id       SERIAL PRIMARY KEY,
-    name     VARCHAR(255) NOT NULL,
-    channel  VARCHAR(255) NOT NULL,
-    language VARCHAR(10)  NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    id         SERIAL PRIMARY KEY,
+    name       VARCHAR(255) NOT NULL,
+    channel    VARCHAR(255) NOT NULL,
+    language   VARCHAR(10)  NOT NULL,
+    created_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Content provider category mappings table


### PR DESCRIPTION
어드민, 스케줄러에서 Content를 만들 때마다 `newsletterName`을 키로 ContentProvider를 매칭하도록 설정함.
ContentProvider의 언어를 라벨에 사용하도록 수정함