### PR TITLE
AI 작업 실패하면 트랜잭션 롤백하도록 적용

### DIFF
--- a/external/src/main/kotlin/com/nexters/external/exception/AiProcessingException.kt
+++ b/external/src/main/kotlin/com/nexters/external/exception/AiProcessingException.kt
@@ -1,0 +1,6 @@
+package com.nexters.external.exception
+
+class AiProcessingException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/external/src/main/kotlin/com/nexters/external/service/KeywordService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/KeywordService.kt
@@ -8,6 +8,7 @@ import com.nexters.external.dto.KeywordResult
 import com.nexters.external.entity.Content
 import com.nexters.external.entity.ContentKeywordMapping
 import com.nexters.external.entity.ReservedKeyword
+import com.nexters.external.exception.AiProcessingException
 import com.nexters.external.repository.CandidateKeywordRepository
 import com.nexters.external.repository.ContentKeywordMappingRepository
 import com.nexters.external.repository.ReservedKeywordRepository
@@ -69,7 +70,7 @@ class KeywordService(
         }
 
         logger.error("All models failed to extract keywords")
-        return KeywordResult(emptyList(), emptyList(), emptyList())
+        throw AiProcessingException("Failed to extract keywords: all models failed")
     }
 
     @Transactional

--- a/external/src/main/kotlin/com/nexters/external/service/SummaryService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/SummaryService.kt
@@ -7,6 +7,7 @@ import com.nexters.external.dto.GeminiModel
 import com.nexters.external.dto.SummaryResult
 import com.nexters.external.entity.Content
 import com.nexters.external.entity.Summary
+import com.nexters.external.exception.AiProcessingException
 import com.nexters.external.repository.SummaryRepository
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -48,7 +49,7 @@ class SummaryService(
         }
 
         logger.error("All models failed to generate summary")
-        return SummaryResult("", listOf(), null)
+        throw AiProcessingException("Failed to generate summary: all models failed")
     }
 
     fun summarizeAndSave(contentEntity: Content): SummaryResult {

--- a/external/src/test/kotlin/com/nexters/external/service/KeywordServiceTest.kt
+++ b/external/src/test/kotlin/com/nexters/external/service/KeywordServiceTest.kt
@@ -3,6 +3,7 @@ package com.nexters.external.service
 import com.google.genai.types.GenerateContentResponse
 import com.nexters.external.apiclient.GeminiClient
 import com.nexters.external.dto.GeminiModel
+import com.nexters.external.exception.AiProcessingException
 import com.nexters.external.repository.CandidateKeywordRepository
 import com.nexters.external.repository.ContentKeywordMappingRepository
 import com.nexters.external.repository.ReservedKeywordRepository
@@ -11,6 +12,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.test.context.jdbc.Sql
@@ -61,17 +63,15 @@ class KeywordServiceTest {
     }
 
     @Test
-    fun `모든 모델이 null을 반환하면 빈 KeywordResult를 반환한다`() {
+    fun `모든 모델이 null을 반환하면 예외를 발생시킨다`() {
         val inputKeywords = listOf("AI", "기술")
         val content = "인공지능 기술의 발전"
 
         every { geminiClient.requestKeywords(inputKeywords, any(), content) } returns null
 
-        val result = sut.extractKeywords(inputKeywords, content)
-
-        assertEquals(emptyList<String>(), result.matchedKeywords)
-        assertEquals(emptyList<String>(), result.suggestedKeywords)
-        assertEquals(emptyList<String>(), result.provocativeKeywords)
+        assertThrows<AiProcessingException> {
+            sut.extractKeywords(inputKeywords, content)
+        }
     }
 
     @Test

--- a/external/src/test/kotlin/com/nexters/external/service/SummaryServiceTest.kt
+++ b/external/src/test/kotlin/com/nexters/external/service/SummaryServiceTest.kt
@@ -5,6 +5,7 @@ import com.nexters.external.apiclient.GeminiClient
 import com.nexters.external.dto.GeminiModel
 import com.nexters.external.entity.Content
 import com.nexters.external.entity.Summary
+import com.nexters.external.exception.AiProcessingException
 import com.nexters.external.repository.SummaryRepository
 import io.mockk.clearMocks
 import io.mockk.every
@@ -14,6 +15,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -45,16 +47,14 @@ class SummaryServiceTest {
     }
 
     @Test
-    fun `모든 모델이 null을 반환하면 빈 SummaryResult를 반환한다`() {
+    fun `모든 모델이 null을 반환하면 예외를 발생시킨다`() {
         val content = "테스트 콘텐츠"
 
         every { geminiClient.requestSummary(any(), content) } returns null
 
-        val result = sut.summarize(content)
-
-        assertEquals("", result.summary)
-        assertEquals(emptyList<String>(), result.provocativeHeadlines)
-        assertEquals(null, result.usedModel)
+        assertThrows<AiProcessingException> {
+            sut.summarize(content)
+        }
 
         verify(exactly = 1) { geminiClient.requestSummary(GeminiModel.TWO_ZERO_FLASH_LITE, content) }
         verify(exactly = 1) { geminiClient.requestSummary(GeminiModel.TWO_ZERO_FLASH, content) }

--- a/newsletter/src/main/kotlin/com/nexters/newsletter/service/NewsletterProcessingService.kt
+++ b/newsletter/src/main/kotlin/com/nexters/newsletter/service/NewsletterProcessingService.kt
@@ -125,53 +125,43 @@ class NewsletterProcessingService(
             null
         }
 
-    private fun generateSummary(content: Content): Summary? {
+    private fun generateSummary(content: Content): Summary {
         logger.info("Generating summary for content: ${content.title}")
 
-        return try {
-            val summaryResult = summaryService.summarize(content.content)
+        val summaryResult = summaryService.summarize(content.content)
 
-            // Use first provocative headline if available, otherwise use original title
-            val recommendedTitle = summaryResult.provocativeHeadlines.firstOrNull() ?: content.title
+        // Use first provocative headline if available, otherwise use original title
+        val recommendedTitle = summaryResult.provocativeHeadlines.firstOrNull() ?: content.title
 
-            val summary =
-                Summary(
-                    content = content,
-                    title = recommendedTitle,
-                    summarizedContent = summaryResult.summary,
-                    model = summaryResult.usedModel?.modelName ?: "unknown",
-                    summarizedAt = LocalDateTime.now(),
-                    createdAt = LocalDateTime.now(),
-                    updatedAt = LocalDateTime.now(),
-                )
+        val summary =
+            Summary(
+                content = content,
+                title = recommendedTitle,
+                summarizedContent = summaryResult.summary,
+                model = summaryResult.usedModel?.modelName ?: "unknown",
+                summarizedAt = LocalDateTime.now(),
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now(),
+            )
 
-            summaryService.save(summary)
-        } catch (e: Exception) {
-            logger.error("Failed to create summary for content: ${content.title}", e)
-            null
-        }
+        return summaryService.save(summary)
     }
 
     private fun matchKeywords(contents: List<Content>) {
         logger.info("Matching keywords for ${contents.size} contents")
 
         contents.forEach { content ->
-            try {
-                val matchedKeywords = keywordService.matchReservedKeywords(content.content)
+            val matchedKeywords = keywordService.matchReservedKeywords(content.content)
 
-                // 컨텐츠에 키워드 할당
-                val assignedCount = keywordService.assignKeywordsToContent(content, matchedKeywords)
+            // 컨텐츠에 키워드 할당
+            val assignedCount = keywordService.assignKeywordsToContent(content, matchedKeywords)
 
-                logger.debug(
-                    "Matched {} keywords for content: {}, assigned {} new keywords",
-                    matchedKeywords.size,
-                    content.title,
-                    assignedCount
-                )
-            } catch (e: Exception) {
-                logger.error("Failed to match keywords for content: ${content.title}", e)
-                // Continue with other contents even if one fails
-            }
+            logger.debug(
+                "Matched {} keywords for content: {}, assigned {} new keywords",
+                matchedKeywords.size,
+                content.title,
+                assignedCount
+            )
         }
     }
 


### PR DESCRIPTION
요약 생성, 키워드 매칭 같은 AI 작업이 실패하면 트랜잭션 롤백하도록 수정함.

기존 동작은 예외를 catch해서 null 객체를 반환했었음.