### PR TITLE
인기 뉴스레터 랭킹 스냅샷 추가

### DIFF
--- a/admin/src/main/kotlin/com/nexters/admin/controller/ProcessController.kt
+++ b/admin/src/main/kotlin/com/nexters/admin/controller/ProcessController.kt
@@ -11,6 +11,7 @@ import com.nexters.external.repository.ReservedKeywordRepository
 import com.nexters.external.repository.SummaryRepository
 import com.nexters.external.service.ContentAnalysisService
 import com.nexters.external.service.ExposureContentService
+import com.nexters.external.service.GeminiRateLimiterService
 import com.nexters.newsletter.service.NewsletterProcessingService
 import com.nexters.newsletter.service.RssContentService
 import org.springframework.data.domain.Page
@@ -36,7 +37,7 @@ class ProcessController(
     private val exposureContentService: ExposureContentService,
     private val rssContentService: RssContentService,
     private val newsletterProcessingService: NewsletterProcessingService,
-    private val rateLimiterService: com.nexters.external.service.GeminiRateLimiterService,
+    private val rateLimiterService: GeminiRateLimiterService,
 ) {
     @GetMapping("/content/{contentId}/keywords")
     fun getContentKeywords(

--- a/admin/src/main/kotlin/com/nexters/admin/controller/RecommendationController.kt
+++ b/admin/src/main/kotlin/com/nexters/admin/controller/RecommendationController.kt
@@ -3,6 +3,7 @@ package com.nexters.admin.controller
 import com.nexters.admin.repository.CategoryKeywordMappingRepository
 import com.nexters.external.entity.CategoryKeywordMapping
 import com.nexters.external.repository.CategoryRepository
+import com.nexters.external.repository.ContentKeywordMappingRepository
 import com.nexters.external.repository.ContentRepository
 import com.nexters.external.repository.ReservedKeywordRepository
 import com.nexters.external.repository.SummaryRepository
@@ -35,7 +36,7 @@ class RecommendationController(
     private val reservedKeywordRepository: ReservedKeywordRepository,
     private val contentRepository: ContentRepository,
     private val userService: UserService,
-    private val contentKeywordMappingRepository: com.nexters.external.repository.ContentKeywordMappingRepository,
+    private val contentKeywordMappingRepository: ContentKeywordMappingRepository,
 ) {
     @GetMapping("/exposure-contents/all")
     fun getAllExposureContentsWithPaging(

--- a/admin/src/main/kotlin/com/nexters/admin/service/DashboardService.kt
+++ b/admin/src/main/kotlin/com/nexters/admin/service/DashboardService.kt
@@ -17,6 +17,7 @@ import com.nexters.external.repository.NewsletterSourceRepository
 import com.nexters.external.service.GeminiRateLimiterService
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.TemporalAdjusters
@@ -380,7 +381,7 @@ class DashboardService(
                 val startOfWeek =
                     now
                         .toLocalDate()
-                        .with(TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY))
+                        .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
                         .atStartOfDay()
                 Pair(startOfWeek, now)
             }

--- a/api/src/main/kotlin/com/nexters/api/batch/config/BatchLockConfig.kt
+++ b/api/src/main/kotlin/com/nexters/api/batch/config/BatchLockConfig.kt
@@ -1,0 +1,12 @@
+package com.nexters.api.batch.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.integration.support.locks.DefaultLockRegistry
+import org.springframework.integration.support.locks.LockRegistry
+
+@Configuration
+class BatchLockConfig {
+    @Bean
+    fun lockRegistry(): LockRegistry = DefaultLockRegistry()
+}

--- a/api/src/main/kotlin/com/nexters/api/batch/config/PopularNewsletterRankingScheduler.kt
+++ b/api/src/main/kotlin/com/nexters/api/batch/config/PopularNewsletterRankingScheduler.kt
@@ -17,7 +17,7 @@ class PopularNewsletterRankingScheduler(
 ) {
     private val logger = LoggerFactory.getLogger(PopularNewsletterRankingScheduler::class.java)
 
-    @Scheduled(cron = "0 30 7 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 30 23 * * SUN", zone = "Asia/Seoul")
     fun rebuildGlobalRankingSnapshot() {
         logger.info("인기 뉴스레터 랭킹 스냅샷 스케줄 실행 시작")
         popularNewsletterRankingBatchService.rebuildGlobalRanking()

--- a/api/src/main/kotlin/com/nexters/api/batch/config/PopularNewsletterRankingScheduler.kt
+++ b/api/src/main/kotlin/com/nexters/api/batch/config/PopularNewsletterRankingScheduler.kt
@@ -1,0 +1,26 @@
+package com.nexters.api.batch.config
+
+import com.nexters.api.batch.service.PopularNewsletterRankingBatchService
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(
+    name = ["batch.enabled"],
+    havingValue = "true",
+    matchIfMissing = false,
+)
+class PopularNewsletterRankingScheduler(
+    private val popularNewsletterRankingBatchService: PopularNewsletterRankingBatchService,
+) {
+    private val logger = LoggerFactory.getLogger(PopularNewsletterRankingScheduler::class.java)
+
+    @Scheduled(cron = "0 30 7 * * *", zone = "Asia/Seoul")
+    fun rebuildGlobalRankingSnapshot() {
+        logger.info("인기 뉴스레터 랭킹 스냅샷 스케줄 실행 시작")
+        popularNewsletterRankingBatchService.rebuildGlobalRanking()
+        logger.info("인기 뉴스레터 랭킹 스냅샷 스케줄 실행 완료")
+    }
+}

--- a/api/src/main/kotlin/com/nexters/api/batch/controller/AnalyticsController.kt
+++ b/api/src/main/kotlin/com/nexters/api/batch/controller/AnalyticsController.kt
@@ -1,10 +1,15 @@
 package com.nexters.api.batch.controller
 
+import com.nexters.api.batch.dto.DailyAnalyticsReportSendApiResponse
+import com.nexters.api.batch.dto.PopularNewsletterRankingRebuildApiResponse
+import com.nexters.api.batch.dto.WeeklyAnalyticsReportSendApiResponse
 import com.nexters.api.batch.service.DailyAnalyticsService
+import com.nexters.api.batch.service.PopularNewsletterRankingBatchService
 import com.nexters.api.batch.service.WeeklyAnalyticsService
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -21,7 +26,8 @@ import java.time.LocalDate
 )
 class AnalyticsController(
     private val dailyAnalyticsService: DailyAnalyticsService,
-    private val weeklyAnalyticsService: WeeklyAnalyticsService
+    private val weeklyAnalyticsService: WeeklyAnalyticsService,
+    private val popularNewsletterRankingBatchService: PopularNewsletterRankingBatchService,
 ) {
     private val logger = LoggerFactory.getLogger(AnalyticsController::class.java)
 
@@ -30,7 +36,7 @@ class AnalyticsController(
         @RequestParam(required = false)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         date: LocalDate?
-    ): ResponseEntity<Map<String, Any>> =
+    ): ResponseEntity<DailyAnalyticsReportSendApiResponse> =
         try {
             val targetDate = date ?: LocalDate.now().minusDays(1)
             logger.info("수동 일일 리포트 전송 요청: $targetDate")
@@ -39,28 +45,28 @@ class AnalyticsController(
 
             if (success) {
                 ResponseEntity.ok(
-                    mapOf(
-                        "success" to true,
-                        "message" to "일일 리포트가 성공적으로 전송되었습니다.",
-                        "date" to targetDate.toString()
-                    )
+                    DailyAnalyticsReportSendApiResponse(
+                        success = true,
+                        message = "일일 리포트가 성공적으로 전송되었습니다.",
+                        date = targetDate,
+                    ),
                 )
             } else {
-                ResponseEntity.ok(
-                    mapOf(
-                        "success" to false,
-                        "message" to "일일 리포트 전송에 실패했습니다.",
-                        "date" to targetDate.toString()
-                    )
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    DailyAnalyticsReportSendApiResponse(
+                        success = false,
+                        message = "일일 리포트 전송에 실패했습니다.",
+                        date = targetDate,
+                    ),
                 )
             }
         } catch (e: Exception) {
             logger.error("수동 일일 리포트 전송 중 오류 발생", e)
-            ResponseEntity.ok(
-                mapOf(
-                    "success" to false,
-                    "message" to "리포트 전송 중 오류가 발생했습니다: ${e.message}"
-                )
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                DailyAnalyticsReportSendApiResponse(
+                    success = false,
+                    message = "리포트 전송 중 오류가 발생했습니다: ${e.message}",
+                ),
             )
         }
 
@@ -69,7 +75,7 @@ class AnalyticsController(
         @RequestParam(required = false)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         endDate: LocalDate?
-    ): ResponseEntity<Map<String, Any>> =
+    ): ResponseEntity<WeeklyAnalyticsReportSendApiResponse> =
         try {
             val targetEndDate = endDate ?: LocalDate.now().minusDays(1)
             val targetStartDate = targetEndDate.minusDays(6)
@@ -79,30 +85,67 @@ class AnalyticsController(
 
             if (success) {
                 ResponseEntity.ok(
-                    mapOf(
-                        "success" to true,
-                        "message" to "주간 리포트가 성공적으로 전송되었습니다.",
-                        "startDate" to targetStartDate.toString(),
-                        "endDate" to targetEndDate.toString()
-                    )
+                    WeeklyAnalyticsReportSendApiResponse(
+                        success = true,
+                        message = "주간 리포트가 성공적으로 전송되었습니다.",
+                        startDate = targetStartDate,
+                        endDate = targetEndDate,
+                    ),
                 )
             } else {
-                ResponseEntity.ok(
-                    mapOf(
-                        "success" to false,
-                        "message" to "주간 리포트 전송에 실패했습니다.",
-                        "startDate" to targetStartDate.toString(),
-                        "endDate" to targetEndDate.toString()
-                    )
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    WeeklyAnalyticsReportSendApiResponse(
+                        success = false,
+                        message = "주간 리포트 전송에 실패했습니다.",
+                        startDate = targetStartDate,
+                        endDate = targetEndDate,
+                    ),
                 )
             }
         } catch (e: Exception) {
             logger.error("수동 주간 리포트 전송 중 오류 발생", e)
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                WeeklyAnalyticsReportSendApiResponse(
+                    success = false,
+                    message = "주간 리포트 전송 중 오류가 발생했습니다: ${e.message}",
+                ),
+            )
+        }
+
+    @PostMapping("/popular-newsletters/rebuild")
+    fun rebuildPopularNewsletters(
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        endDate: LocalDate?,
+        @RequestParam(defaultValue = "365")
+        lookbackDays: Int,
+        @RequestParam(defaultValue = "20")
+        limit: Int,
+    ): ResponseEntity<PopularNewsletterRankingRebuildApiResponse> =
+        try {
+            val targetEndDate = endDate ?: LocalDate.now()
+            logger.info("인기 뉴스레터 랭킹 스냅샷 수동 재집계 요청: endDate={}, lookbackDays={}, limit={}", targetEndDate, lookbackDays, limit)
+
+            val snapshot = popularNewsletterRankingBatchService.rebuildGlobalRanking(targetEndDate, lookbackDays, limit)
+
             ResponseEntity.ok(
-                mapOf(
-                    "success" to false,
-                    "message" to "주간 리포트 전송 중 오류가 발생했습니다: ${e.message}"
-                )
+                PopularNewsletterRankingRebuildApiResponse(
+                    success = true,
+                    message = "인기 뉴스레터 랭킹 스냅샷 재집계를 완료했습니다.",
+                    snapshotId = snapshot.id,
+                    status = snapshot.status,
+                    resolvedItemCount = snapshot.resolvedItemCount,
+                    windowStartDate = snapshot.windowStartDate,
+                    windowEndDate = snapshot.windowEndDate,
+                ),
+            )
+        } catch (e: Exception) {
+            logger.error("인기 뉴스레터 랭킹 스냅샷 수동 재집계 중 오류 발생", e)
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                PopularNewsletterRankingRebuildApiResponse(
+                    success = false,
+                    message = "인기 뉴스레터 랭킹 스냅샷 재집계 중 오류가 발생했습니다: ${e.message}",
+                ),
             )
         }
 }

--- a/api/src/main/kotlin/com/nexters/api/batch/dto/DailyAnalyticsReportSendApiResponse.kt
+++ b/api/src/main/kotlin/com/nexters/api/batch/dto/DailyAnalyticsReportSendApiResponse.kt
@@ -1,0 +1,9 @@
+package com.nexters.api.batch.dto
+
+import java.time.LocalDate
+
+data class DailyAnalyticsReportSendApiResponse(
+    val success: Boolean,
+    val message: String,
+    val date: LocalDate? = null,
+)

--- a/api/src/main/kotlin/com/nexters/api/batch/dto/PopularNewsletterRankingRebuildApiResponse.kt
+++ b/api/src/main/kotlin/com/nexters/api/batch/dto/PopularNewsletterRankingRebuildApiResponse.kt
@@ -1,0 +1,14 @@
+package com.nexters.api.batch.dto
+
+import com.nexters.external.enums.PopularNewsletterSnapshotStatus
+import java.time.LocalDate
+
+data class PopularNewsletterRankingRebuildApiResponse(
+    val success: Boolean,
+    val message: String,
+    val snapshotId: Long? = null,
+    val status: PopularNewsletterSnapshotStatus? = null,
+    val resolvedItemCount: Int? = null,
+    val windowStartDate: LocalDate? = null,
+    val windowEndDate: LocalDate? = null,
+)

--- a/api/src/main/kotlin/com/nexters/api/batch/dto/WeeklyAnalyticsReportSendApiResponse.kt
+++ b/api/src/main/kotlin/com/nexters/api/batch/dto/WeeklyAnalyticsReportSendApiResponse.kt
@@ -1,0 +1,10 @@
+package com.nexters.api.batch.dto
+
+import java.time.LocalDate
+
+data class WeeklyAnalyticsReportSendApiResponse(
+    val success: Boolean,
+    val message: String,
+    val startDate: LocalDate? = null,
+    val endDate: LocalDate? = null,
+)

--- a/api/src/main/kotlin/com/nexters/api/batch/service/GoogleAnalyticsService.kt
+++ b/api/src/main/kotlin/com/nexters/api/batch/service/GoogleAnalyticsService.kt
@@ -134,6 +134,18 @@ class GoogleAnalyticsService(
         }
     }
 
+    fun getTopNewsletterClicksForRollingWindow(
+        endDate: LocalDate,
+        lookbackDays: Int = 365,
+        limit: Int = 20,
+    ): List<NewsletterClick> {
+        val windowStartDate = endDate.minusDays(lookbackDays.toLong() - 1)
+        val startDateString = windowStartDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        val endDateString = endDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+
+        return getTopNewsletterClicksForPeriod(startDateString, endDateString, limit)
+    }
+
     private fun getYesterdayTotalUsers(yesterdayString: String): Long =
         try {
             logger.info("어제 총 방문자 수 조회 시작: $yesterdayString")
@@ -392,7 +404,8 @@ class GoogleAnalyticsService(
 
     private fun getTopNewsletterClicksForPeriod(
         startDateString: String,
-        endDateString: String
+        endDateString: String,
+        limit: Int = 10,
     ): List<NewsletterClick> =
         try {
             logger.info("Newsletter 클릭 데이터 조회 시작 ($startDateString ~ $endDateString)")
@@ -442,7 +455,7 @@ class GoogleAnalyticsService(
                                     .build()
                             ).setDesc(true)
                             .build()
-                    ).setLimit(10) // 주간 리포트는 TOP 10으로 확장
+                    ).setLimit(limit.toLong())
                     .build()
 
             val response = analyticsClient.runReport(newsletterClickRequest)

--- a/api/src/main/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchService.kt
+++ b/api/src/main/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchService.kt
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 import java.time.LocalDate
+import java.util.concurrent.locks.ReentrantLock
 
 @Service
 @ConditionalOnProperty(
@@ -26,76 +27,82 @@ class PopularNewsletterRankingBatchService(
     private val popularNewsletterSnapshotService: PopularNewsletterSnapshotService,
 ) {
     private val logger = LoggerFactory.getLogger(PopularNewsletterRankingBatchService::class.java)
+    private val rebuildLock = ReentrantLock() // instance가 늘어나면 락 구현체 변경 필요, 분산 락으로 전환
 
     fun rebuildGlobalRanking(
         endDate: LocalDate = LocalDate.now(),
         lookbackDays: Int = 365,
         limit: Int = 20,
     ): PopularNewsletterSnapshot {
-        val windowStartDate = endDate.minusDays(lookbackDays.toLong() - 1)
+        rebuildLock.lock()
+        try {
+            val windowStartDate = endDate.minusDays(lookbackDays.toLong() - 1)
 
-        return try {
-            val clicks = googleAnalyticsService.getTopNewsletterClicksForRollingWindow(endDate, lookbackDays, limit)
-            val resolutionsByObjectId =
-                popularNewsletterObjectIdResolverService.resolveObjectIds(
-                    clicks.map { click -> click.objectId },
-                )
-            val items =
-                clicks.mapIndexed { index, click ->
-                    val resolution =
-                        resolutionsByObjectId[click.objectId]
-                            ?: PopularNewsletterObjectResolution(
-                                resolutionStatus = PopularNewsletterResolutionStatus.UNRESOLVED,
-                            )
-
-                    SavePopularNewsletterSnapshotItemCommand(
-                        rank = index + 1,
-                        rawObjectId = click.objectId,
-                        clickCount = click.clickCount,
-                        resolvedContentId = resolution.resolvedContentId,
-                        resolvedExposureContentId = resolution.resolvedExposureContentId,
-                        resolutionStatus = resolution.resolutionStatus,
+            return try {
+                val clicks = googleAnalyticsService.getTopNewsletterClicksForRollingWindow(endDate, lookbackDays, limit)
+                val resolutionsByObjectId =
+                    popularNewsletterObjectIdResolverService.resolveObjectIds(
+                        clicks.map { click -> click.objectId },
                     )
-                }
+                val items =
+                    clicks.mapIndexed { index, click ->
+                        val resolution =
+                            resolutionsByObjectId[click.objectId]
+                                ?: PopularNewsletterObjectResolution(
+                                    resolutionStatus = PopularNewsletterResolutionStatus.UNRESOLVED,
+                                )
 
-            val resolvedItemCount = items.count { it.resolvedExposureContentId != null }
+                        SavePopularNewsletterSnapshotItemCommand(
+                            rank = index + 1,
+                            rawObjectId = click.objectId,
+                            clickCount = click.clickCount,
+                            resolvedContentId = resolution.resolvedContentId,
+                            resolvedExposureContentId = resolution.resolvedExposureContentId,
+                            resolutionStatus = resolution.resolutionStatus,
+                        )
+                    }
 
-            popularNewsletterSnapshotService
-                .saveSnapshot(
+                val resolvedItemCount = items.count { it.resolvedExposureContentId != null }
+
+                popularNewsletterSnapshotService
+                    .saveSnapshot(
+                        SavePopularNewsletterSnapshotCommand(
+                            segmentType = PopularNewsletterSegmentType.GLOBAL,
+                            windowStartDate = windowStartDate,
+                            windowEndDate = endDate,
+                            sourceEventName = NEWSLETTER_CLICK_EVENT_NAME,
+                            candidateLimit = limit,
+                            resolvedItemCount = resolvedItemCount,
+                            status = PopularNewsletterSnapshotStatus.SUCCESS,
+                            items = items,
+                        ),
+                    ).also { snapshot ->
+                        logger.info(
+                            "인기 뉴스레터 랭킹 스냅샷 저장 완료: snapshotId={}, resolvedItemCount={}, candidateLimit={}",
+                            snapshot.id,
+                            resolvedItemCount,
+                            limit,
+                        )
+                    }
+            } catch (e: Exception) {
+                logger.error("인기 뉴스레터 랭킹 스냅샷 생성 중 오류 발생", e)
+
+                popularNewsletterSnapshotService.saveSnapshot(
                     SavePopularNewsletterSnapshotCommand(
                         segmentType = PopularNewsletterSegmentType.GLOBAL,
                         windowStartDate = windowStartDate,
                         windowEndDate = endDate,
                         sourceEventName = NEWSLETTER_CLICK_EVENT_NAME,
                         candidateLimit = limit,
-                        resolvedItemCount = resolvedItemCount,
-                        status = PopularNewsletterSnapshotStatus.SUCCESS,
-                        items = items,
+                        resolvedItemCount = 0,
+                        status = PopularNewsletterSnapshotStatus.FAILED,
                     ),
-                ).also { snapshot ->
-                    logger.info(
-                        "인기 뉴스레터 랭킹 스냅샷 저장 완료: snapshotId={}, resolvedItemCount={}, candidateLimit={}",
-                        snapshot.id,
-                        resolvedItemCount,
-                        limit,
-                    )
-                }
-        } catch (e: Exception) {
-            logger.error("인기 뉴스레터 랭킹 스냅샷 생성 중 오류 발생", e)
+                )
 
-            popularNewsletterSnapshotService.saveSnapshot(
-                SavePopularNewsletterSnapshotCommand(
-                    segmentType = PopularNewsletterSegmentType.GLOBAL,
-                    windowStartDate = windowStartDate,
-                    windowEndDate = endDate,
-                    sourceEventName = NEWSLETTER_CLICK_EVENT_NAME,
-                    candidateLimit = limit,
-                    resolvedItemCount = 0,
-                    status = PopularNewsletterSnapshotStatus.FAILED,
-                ),
-            )
-
-            throw IllegalStateException("인기 뉴스레터 랭킹 스냅샷 생성에 실패했습니다.", e)
+                throw IllegalStateException("인기 뉴스레터 랭킹 스냅샷 생성에 실패했습니다.", e)
+            }
+        } finally {
+            rebuildLock.unlock()
         }
     }
 

--- a/api/src/main/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchService.kt
+++ b/api/src/main/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchService.kt
@@ -1,0 +1,95 @@
+package com.nexters.api.batch.service
+
+import com.nexters.external.entity.PopularNewsletterSnapshot
+import com.nexters.external.enums.PopularNewsletterSegmentType
+import com.nexters.external.enums.PopularNewsletterSnapshotStatus
+import com.nexters.external.service.PopularNewsletterObjectIdResolverService
+import com.nexters.external.service.PopularNewsletterSnapshotService
+import com.nexters.external.service.SavePopularNewsletterSnapshotCommand
+import com.nexters.external.service.SavePopularNewsletterSnapshotItemCommand
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+@ConditionalOnProperty(
+    name = ["batch.enabled"],
+    havingValue = "true",
+    matchIfMissing = false,
+)
+class PopularNewsletterRankingBatchService(
+    private val googleAnalyticsService: GoogleAnalyticsService,
+    private val popularNewsletterObjectIdResolverService: PopularNewsletterObjectIdResolverService,
+    private val popularNewsletterSnapshotService: PopularNewsletterSnapshotService,
+) {
+    private val logger = LoggerFactory.getLogger(PopularNewsletterRankingBatchService::class.java)
+
+    fun rebuildGlobalRanking(
+        endDate: LocalDate = LocalDate.now(),
+        lookbackDays: Int = 365,
+        limit: Int = 20,
+    ): PopularNewsletterSnapshot {
+        val windowStartDate = endDate.minusDays(lookbackDays.toLong() - 1)
+
+        return try {
+            val clicks = googleAnalyticsService.getTopNewsletterClicksForRollingWindow(endDate, lookbackDays, limit)
+            val items =
+                clicks.mapIndexed { index, click ->
+                    val resolution = popularNewsletterObjectIdResolverService.resolveObjectId(click.objectId)
+
+                    SavePopularNewsletterSnapshotItemCommand(
+                        rank = index + 1,
+                        rawObjectId = click.objectId,
+                        clickCount = click.clickCount,
+                        resolvedContentId = resolution.resolvedContentId,
+                        resolvedExposureContentId = resolution.resolvedExposureContentId,
+                        resolutionStatus = resolution.resolutionStatus,
+                    )
+                }
+
+            val resolvedItemCount = items.count { it.resolvedExposureContentId != null }
+
+            popularNewsletterSnapshotService
+                .saveSnapshot(
+                    SavePopularNewsletterSnapshotCommand(
+                        segmentType = PopularNewsletterSegmentType.GLOBAL,
+                        windowStartDate = windowStartDate,
+                        windowEndDate = endDate,
+                        sourceEventName = NEWSLETTER_CLICK_EVENT_NAME,
+                        candidateLimit = limit,
+                        resolvedItemCount = resolvedItemCount,
+                        status = PopularNewsletterSnapshotStatus.SUCCESS,
+                        items = items,
+                    ),
+                ).also { snapshot ->
+                    logger.info(
+                        "인기 뉴스레터 랭킹 스냅샷 저장 완료: snapshotId={}, resolvedItemCount={}, candidateLimit={}",
+                        snapshot.id,
+                        resolvedItemCount,
+                        limit,
+                    )
+                }
+        } catch (e: Exception) {
+            logger.error("인기 뉴스레터 랭킹 스냅샷 생성 중 오류 발생", e)
+
+            popularNewsletterSnapshotService.saveSnapshot(
+                SavePopularNewsletterSnapshotCommand(
+                    segmentType = PopularNewsletterSegmentType.GLOBAL,
+                    windowStartDate = windowStartDate,
+                    windowEndDate = endDate,
+                    sourceEventName = NEWSLETTER_CLICK_EVENT_NAME,
+                    candidateLimit = limit,
+                    resolvedItemCount = 0,
+                    status = PopularNewsletterSnapshotStatus.FAILED,
+                ),
+            )
+
+            throw IllegalStateException("인기 뉴스레터 랭킹 스냅샷 생성에 실패했습니다.", e)
+        }
+    }
+
+    companion object {
+        const val NEWSLETTER_CLICK_EVENT_NAME: String = "click_newsletter"
+    }
+}

--- a/api/src/main/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchService.kt
+++ b/api/src/main/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchService.kt
@@ -1,9 +1,11 @@
 package com.nexters.api.batch.service
 
 import com.nexters.external.entity.PopularNewsletterSnapshot
+import com.nexters.external.enums.PopularNewsletterResolutionStatus
 import com.nexters.external.enums.PopularNewsletterSegmentType
 import com.nexters.external.enums.PopularNewsletterSnapshotStatus
 import com.nexters.external.service.PopularNewsletterObjectIdResolverService
+import com.nexters.external.service.PopularNewsletterObjectResolution
 import com.nexters.external.service.PopularNewsletterSnapshotService
 import com.nexters.external.service.SavePopularNewsletterSnapshotCommand
 import com.nexters.external.service.SavePopularNewsletterSnapshotItemCommand
@@ -34,9 +36,17 @@ class PopularNewsletterRankingBatchService(
 
         return try {
             val clicks = googleAnalyticsService.getTopNewsletterClicksForRollingWindow(endDate, lookbackDays, limit)
+            val resolutionsByObjectId =
+                popularNewsletterObjectIdResolverService.resolveObjectIds(
+                    clicks.map { click -> click.objectId },
+                )
             val items =
                 clicks.mapIndexed { index, click ->
-                    val resolution = popularNewsletterObjectIdResolverService.resolveObjectId(click.objectId)
+                    val resolution =
+                        resolutionsByObjectId[click.objectId]
+                            ?: PopularNewsletterObjectResolution(
+                                resolutionStatus = PopularNewsletterResolutionStatus.UNRESOLVED,
+                            )
 
                     SavePopularNewsletterSnapshotItemCommand(
                         rank = index + 1,

--- a/api/src/main/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchService.kt
+++ b/api/src/main/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchService.kt
@@ -11,9 +11,9 @@ import com.nexters.external.service.SavePopularNewsletterSnapshotCommand
 import com.nexters.external.service.SavePopularNewsletterSnapshotItemCommand
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.integration.support.locks.LockRegistry
 import org.springframework.stereotype.Service
 import java.time.LocalDate
-import java.util.concurrent.locks.ReentrantLock
 
 @Service
 @ConditionalOnProperty(
@@ -25,15 +25,16 @@ class PopularNewsletterRankingBatchService(
     private val googleAnalyticsService: GoogleAnalyticsService,
     private val popularNewsletterObjectIdResolverService: PopularNewsletterObjectIdResolverService,
     private val popularNewsletterSnapshotService: PopularNewsletterSnapshotService,
+    private val lockRegistry: LockRegistry,
 ) {
     private val logger = LoggerFactory.getLogger(PopularNewsletterRankingBatchService::class.java)
-    private val rebuildLock = ReentrantLock() // instance가 늘어나면 락 구현체 변경 필요, 분산 락으로 전환
 
     fun rebuildGlobalRanking(
         endDate: LocalDate = LocalDate.now(),
         lookbackDays: Int = 365,
         limit: Int = 20,
     ): PopularNewsletterSnapshot {
+        val rebuildLock = lockRegistry.obtain(POPULAR_NEWSLETTER_RANKING_REBUILD_LOCK_KEY)
         rebuildLock.lock()
         try {
             val windowStartDate = endDate.minusDays(lookbackDays.toLong() - 1)
@@ -108,5 +109,6 @@ class PopularNewsletterRankingBatchService(
 
     companion object {
         const val NEWSLETTER_CLICK_EVENT_NAME: String = "click_newsletter"
+        private const val POPULAR_NEWSLETTER_RANKING_REBUILD_LOCK_KEY: String = "popular-newsletter-ranking-rebuild"
     }
 }

--- a/api/src/main/kotlin/com/nexters/api/controller/NewsletterApiController.kt
+++ b/api/src/main/kotlin/com/nexters/api/controller/NewsletterApiController.kt
@@ -2,7 +2,6 @@ package com.nexters.api.controller
 
 import com.nexters.api.dto.ContentProviderApiResponse
 import com.nexters.api.dto.ContentViewApiResponse
-import com.nexters.api.dto.ContentViewApiResponse.ContentCardApiResponse
 import com.nexters.api.dto.CreateContentApiRequest
 import com.nexters.api.dto.CreateContentApiResponse
 import com.nexters.api.dto.CreateContentProviderRequestApiRequest
@@ -10,6 +9,7 @@ import com.nexters.api.dto.ExposureContentApiResponse
 import com.nexters.api.dto.ExposureContentListApiResponse
 import com.nexters.api.enums.Language
 import com.nexters.api.exception.UnauthorizedException
+import com.nexters.api.service.NewsletterContentsService
 import com.nexters.api.util.TokenUtil
 import com.nexters.external.service.ContentProviderRequestService
 import com.nexters.external.service.ContentService
@@ -38,6 +38,7 @@ import java.time.LocalDate
 @Tag(name = "Newsletter API", description = "뉴스레터 관련 API")
 class NewsletterApiController(
     private val dayArchiveResolver: DailyContentArchiveResolver,
+    private val newsletterContentsService: NewsletterContentsService,
     private val exposureContentService: ExposureContentService,
     private val contentService: ContentService,
     private val contentProviderRequestService: ContentProviderRequestService,
@@ -47,23 +48,7 @@ class NewsletterApiController(
     fun getNewsletterContents(
         @PathVariable userId: Long,
         publishedDate: LocalDate = LocalDate.now(),
-    ): ContentViewApiResponse =
-        ContentViewApiResponse(
-            publishedDate = publishedDate,
-            cards =
-                dayArchiveResolver.resolveTodayContentArchive(userId, publishedDate).exposureContents.map {
-                    ContentCardApiResponse(
-                        id = it.id!!,
-                        title = it.provocativeHeadline,
-                        topKeyword = it.provocativeKeyword,
-                        summary = it.summaryContent,
-                        contentUrl = it.content.originalUrl,
-                        imageUrl = it.content.imageUrl,
-                        newsletterName = it.content.newsletterName,
-                        language = Language.fromString(it.content.contentProvider?.language),
-                    )
-                },
-        )
+    ): ContentViewApiResponse = newsletterContentsService.getNewsletterContents(userId, publishedDate)
 
     @PostMapping("/contents/{userId}/refresh")
     @ApiResponses(

--- a/api/src/main/kotlin/com/nexters/api/dto/ContentViewApiResponse.kt
+++ b/api/src/main/kotlin/com/nexters/api/dto/ContentViewApiResponse.kt
@@ -5,6 +5,7 @@ import java.time.LocalDate
 
 data class ContentViewApiResponse(
     val publishedDate: LocalDate,
+    val trendingCard: ContentCardApiResponse?,
     val cards: List<ContentCardApiResponse>,
 ) {
     data class ContentCardApiResponse(

--- a/api/src/main/kotlin/com/nexters/api/service/NewsletterContentsService.kt
+++ b/api/src/main/kotlin/com/nexters/api/service/NewsletterContentsService.kt
@@ -1,0 +1,49 @@
+package com.nexters.api.service
+
+import com.nexters.api.dto.ContentViewApiResponse
+import com.nexters.api.enums.Language
+import com.nexters.external.entity.ExposureContent
+import com.nexters.external.service.PopularNewsletterSnapshotService
+import com.nexters.newsletter.resolver.DailyContentArchiveResolver
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+class NewsletterContentsService(
+    private val dayArchiveResolver: DailyContentArchiveResolver,
+    private val popularNewsletterSnapshotService: PopularNewsletterSnapshotService,
+) {
+    fun getNewsletterContents(
+        userId: Long,
+        publishedDate: LocalDate = LocalDate.now(),
+    ): ContentViewApiResponse {
+        val cards =
+            dayArchiveResolver.resolveTodayContentArchive(userId, publishedDate).exposureContents.map { exposureContent ->
+                exposureContent.toCard()
+            }
+
+        val trendingCard =
+            popularNewsletterSnapshotService
+                .findLatestFeaturedExposureContent()
+                ?.toCard()
+                ?: cards.firstOrNull()
+
+        return ContentViewApiResponse(
+            publishedDate = publishedDate,
+            trendingCard = trendingCard,
+            cards = cards,
+        )
+    }
+
+    private fun ExposureContent.toCard(): ContentViewApiResponse.ContentCardApiResponse =
+        ContentViewApiResponse.ContentCardApiResponse(
+            id = this.id!!,
+            title = this.provocativeHeadline,
+            topKeyword = this.provocativeKeyword,
+            summary = this.summaryContent,
+            contentUrl = this.content.originalUrl,
+            imageUrl = this.content.imageUrl,
+            newsletterName = this.content.newsletterName,
+            language = Language.fromString(this.content.contentProvider?.language),
+        )
+}

--- a/api/src/test/kotlin/com/nexters/api/batch/controller/AnalyticsControllerTest.kt
+++ b/api/src/test/kotlin/com/nexters/api/batch/controller/AnalyticsControllerTest.kt
@@ -1,0 +1,84 @@
+package com.nexters.api.batch.controller
+
+import com.nexters.api.batch.service.DailyAnalyticsService
+import com.nexters.api.batch.service.PopularNewsletterRankingBatchService
+import com.nexters.api.batch.service.WeeklyAnalyticsService
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDate
+
+@WebMvcTest(controllers = [AnalyticsController::class], properties = ["batch.enabled=true"])
+@ActiveProfiles("test")
+class AnalyticsControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var dailyAnalyticsService: DailyAnalyticsService
+
+    @MockitoBean
+    private lateinit var weeklyAnalyticsService: WeeklyAnalyticsService
+
+    @MockitoBean
+    private lateinit var popularNewsletterRankingBatchService: PopularNewsletterRankingBatchService
+
+    @Test
+    fun `sendDailyReport should return 500 when report generation fails`() {
+        val date = LocalDate.of(2026, 4, 18)
+
+        Mockito
+            .`when`(dailyAnalyticsService.generateAndSendDailyReport(date))
+            .thenReturn(false)
+
+        mockMvc
+            .perform(
+                post("/api/analytics/report/send")
+                    .param("date", date.toString()),
+            ).andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.message").value("일일 리포트 전송에 실패했습니다."))
+            .andExpect(jsonPath("$.date").value("2026-04-18"))
+    }
+
+    @Test
+    fun `sendWeeklyReport should return 500 when exception occurs`() {
+        val endDate = LocalDate.of(2026, 4, 18)
+
+        Mockito
+            .`when`(weeklyAnalyticsService.generateAndSendWeeklyReport(endDate))
+            .thenThrow(IllegalStateException("weekly failed"))
+
+        mockMvc
+            .perform(
+                post("/api/analytics/report/weekly/send")
+                    .param("endDate", endDate.toString()),
+            ).andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.message").value("주간 리포트 전송 중 오류가 발생했습니다: weekly failed"))
+    }
+
+    @Test
+    fun `rebuildPopularNewsletters should return 500 when rebuild throws`() {
+        val endDate = LocalDate.of(2026, 4, 19)
+
+        Mockito
+            .`when`(popularNewsletterRankingBatchService.rebuildGlobalRanking(endDate, 365, 20))
+            .thenThrow(IllegalStateException("rebuild failed"))
+
+        mockMvc
+            .perform(
+                post("/api/analytics/popular-newsletters/rebuild")
+                    .param("endDate", endDate.toString()),
+            ).andExpect(status().isInternalServerError)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.message").value("인기 뉴스레터 랭킹 스냅샷 재집계 중 오류가 발생했습니다: rebuild failed"))
+    }
+}

--- a/api/src/test/kotlin/com/nexters/api/batch/service/GoogleAnalyticsServiceTest.kt
+++ b/api/src/test/kotlin/com/nexters/api/batch/service/GoogleAnalyticsServiceTest.kt
@@ -1,0 +1,77 @@
+package com.nexters.api.batch.service
+
+import com.google.analytics.data.v1beta.BetaAnalyticsDataClient
+import com.google.analytics.data.v1beta.DimensionValue
+import com.google.analytics.data.v1beta.MetricValue
+import com.google.analytics.data.v1beta.Row
+import com.google.analytics.data.v1beta.RunReportRequest
+import com.google.analytics.data.v1beta.RunReportResponse
+import com.nexters.api.batch.dto.NewsletterClick
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito
+import org.springframework.test.util.ReflectionTestUtils
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GoogleAnalyticsServiceTest {
+    private val analyticsClient: BetaAnalyticsDataClient = Mockito.mock(BetaAnalyticsDataClient::class.java)
+
+    private val sut = GoogleAnalyticsService(analyticsClient)
+
+    @BeforeEach
+    fun setUp() {
+        ReflectionTestUtils.setField(sut, "propertyId", "test-property")
+    }
+
+    @Test
+    fun `getTopNewsletterClicksForRollingWindow should request rolling 365 day click report`() {
+        val endDate = LocalDate.of(2026, 4, 18)
+        val response =
+            RunReportResponse
+                .newBuilder()
+                .addRows(
+                    Row
+                        .newBuilder()
+                        .addDimensionValues(DimensionValue.newBuilder().setValue("object-1").build())
+                        .addMetricValues(MetricValue.newBuilder().setValue("42").build())
+                        .build(),
+                ).build()
+
+        Mockito
+            .`when`(analyticsClient.runReport(any()))
+            .thenReturn(response)
+
+        val result = sut.getTopNewsletterClicksForRollingWindow(endDate)
+
+        assertEquals(listOf(NewsletterClick(objectId = "object-1", clickCount = 42L)), result)
+
+        val requestCaptor = ArgumentCaptor.forClass(RunReportRequest::class.java)
+        Mockito.verify(analyticsClient).runReport(requestCaptor.capture())
+
+        val request = requestCaptor.value
+        assertEquals("properties/test-property", request.property)
+        assertEquals("2025-04-19", request.dateRangesList.single().startDate)
+        assertEquals("2026-04-18", request.dateRangesList.single().endDate)
+        assertEquals("customEvent:object_id", request.dimensionsList.single().name)
+        assertEquals("eventCount", request.metricsList.single().name)
+        assertEquals("eventName", request.dimensionFilter.filter.fieldName)
+        assertEquals("click_newsletter", request.dimensionFilter.filter.stringFilter.value)
+        assertTrue(request.orderBysList.single().desc)
+        assertEquals(
+            "eventCount",
+            request.orderBysList
+                .single()
+                .metric.metricName
+        )
+        assertEquals(20L, request.limit)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> any(): T {
+        Mockito.any<T>()
+        return null as T
+    }
+}

--- a/api/src/test/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchServiceTest.kt
+++ b/api/src/test/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchServiceTest.kt
@@ -12,6 +12,7 @@ import com.nexters.external.service.SavePopularNewsletterSnapshotCommand
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
+import org.springframework.integration.support.locks.DefaultLockRegistry
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.concurrent.CountDownLatch
@@ -30,12 +31,14 @@ class PopularNewsletterRankingBatchServiceTest {
         Mockito.mock(PopularNewsletterObjectIdResolverService::class.java)
     private val popularNewsletterSnapshotService: PopularNewsletterSnapshotService =
         Mockito.mock(PopularNewsletterSnapshotService::class.java)
+    private val lockRegistry = DefaultLockRegistry()
 
     private val sut =
         PopularNewsletterRankingBatchService(
             googleAnalyticsService = googleAnalyticsService,
             popularNewsletterObjectIdResolverService = popularNewsletterObjectIdResolverService,
             popularNewsletterSnapshotService = popularNewsletterSnapshotService,
+            lockRegistry = lockRegistry,
         )
 
     @Test

--- a/api/src/test/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchServiceTest.kt
+++ b/api/src/test/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchServiceTest.kt
@@ -8,6 +8,7 @@ import com.nexters.external.enums.PopularNewsletterSnapshotStatus
 import com.nexters.external.service.PopularNewsletterObjectIdResolverService
 import com.nexters.external.service.PopularNewsletterObjectResolution
 import com.nexters.external.service.PopularNewsletterSnapshotService
+import com.nexters.external.service.SavePopularNewsletterSnapshotCommand
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
@@ -35,7 +36,7 @@ class PopularNewsletterRankingBatchServiceTest {
     @Test
     fun `rebuildGlobalRanking should save success snapshot with resolved and unresolved items`() {
         val endDate = LocalDate.of(2026, 4, 18)
-        var savedCommand: com.nexters.external.service.SavePopularNewsletterSnapshotCommand? = null
+        var savedCommand: SavePopularNewsletterSnapshotCommand? = null
         val savedSnapshot =
             PopularNewsletterSnapshot(
                 id = 100L,
@@ -58,19 +59,19 @@ class PopularNewsletterRankingBatchServiceTest {
                 ),
             )
         Mockito
-            .`when`(popularNewsletterObjectIdResolverService.resolveObjectId("11"))
+            .`when`(popularNewsletterObjectIdResolverService.resolveObjectIds(listOf("11", "unresolved-object")))
             .thenReturn(
-                PopularNewsletterObjectResolution(
-                    resolvedContentId = 101L,
-                    resolvedExposureContentId = 11L,
-                    resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
-                ),
-            )
-        Mockito
-            .`when`(popularNewsletterObjectIdResolverService.resolveObjectId("unresolved-object"))
-            .thenReturn(
-                PopularNewsletterObjectResolution(
-                    resolutionStatus = PopularNewsletterResolutionStatus.UNRESOLVED,
+                mapOf(
+                    "11" to
+                        PopularNewsletterObjectResolution(
+                            resolvedContentId = 101L,
+                            resolvedExposureContentId = 11L,
+                            resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
+                        ),
+                    "unresolved-object" to
+                        PopularNewsletterObjectResolution(
+                            resolutionStatus = PopularNewsletterResolutionStatus.UNRESOLVED,
+                        ),
                 ),
             )
         Mockito
@@ -106,7 +107,7 @@ class PopularNewsletterRankingBatchServiceTest {
     @Test
     fun `rebuildGlobalRanking should save failed snapshot and throw when ga query fails`() {
         val endDate = LocalDate.of(2026, 4, 18)
-        var savedCommand: com.nexters.external.service.SavePopularNewsletterSnapshotCommand? = null
+        var savedCommand: SavePopularNewsletterSnapshotCommand? = null
 
         Mockito
             .`when`(googleAnalyticsService.getTopNewsletterClicksForRollingWindow(endDate, 365, 20))

--- a/api/src/test/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchServiceTest.kt
+++ b/api/src/test/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchServiceTest.kt
@@ -14,7 +14,12 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -140,6 +145,94 @@ class PopularNewsletterRankingBatchServiceTest {
         assertEquals(PopularNewsletterSnapshotStatus.FAILED, command.status)
         assertEquals(0, command.resolvedItemCount)
         assertTrue(command.items.isEmpty())
+    }
+
+    @Test
+    fun `rebuildGlobalRanking should serialize concurrent executions with lock`() {
+        val endDate = LocalDate.of(2026, 4, 18)
+        val gaInvocationCount = AtomicInteger(0)
+        val saveInvocationCount = AtomicInteger(0)
+        val firstExecutionStarted = CountDownLatch(1)
+        val allowFirstExecutionToContinue = CountDownLatch(1)
+        val secondExecutionEnteredGa = CountDownLatch(1)
+
+        Mockito
+            .`when`(googleAnalyticsService.getTopNewsletterClicksForRollingWindow(endDate, 365, 20))
+            .thenAnswer {
+                when (gaInvocationCount.incrementAndGet()) {
+                    1 -> {
+                        firstExecutionStarted.countDown()
+                        assertTrue(allowFirstExecutionToContinue.await(5, TimeUnit.SECONDS))
+                        listOf(NewsletterClick(objectId = "11", clickCount = 120L))
+                    }
+
+                    2 -> {
+                        secondExecutionEnteredGa.countDown()
+                        listOf(NewsletterClick(objectId = "11", clickCount = 120L))
+                    }
+
+                    else -> error("Unexpected invocation count")
+                }
+            }
+        Mockito
+            .`when`(popularNewsletterObjectIdResolverService.resolveObjectIds(listOf("11")))
+            .thenReturn(
+                mapOf(
+                    "11" to
+                        PopularNewsletterObjectResolution(
+                            resolvedContentId = 101L,
+                            resolvedExposureContentId = 11L,
+                            resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
+                        ),
+                ),
+            )
+        Mockito
+            .doAnswer { invocation ->
+                val command = invocation.getArgument<SavePopularNewsletterSnapshotCommand>(0)
+                val snapshotId = saveInvocationCount.incrementAndGet().toLong()
+
+                PopularNewsletterSnapshot(
+                    id = snapshotId,
+                    segmentType = command.segmentType,
+                    windowStartDate = command.windowStartDate,
+                    windowEndDate = command.windowEndDate,
+                    generatedAt = LocalDateTime.of(2026, 4, 18, 7, 30).plusMinutes(snapshotId),
+                    sourceEventName = command.sourceEventName,
+                    candidateLimit = command.candidateLimit,
+                    resolvedItemCount = command.resolvedItemCount,
+                    status = command.status,
+                )
+            }.`when`(popularNewsletterSnapshotService)
+            .saveSnapshot(any())
+
+        val executor = Executors.newFixedThreadPool(2)
+
+        try {
+            val firstFuture =
+                executor.submit<PopularNewsletterSnapshot> {
+                    sut.rebuildGlobalRanking(endDate, 365, 20)
+                }
+
+            assertTrue(firstExecutionStarted.await(5, TimeUnit.SECONDS))
+
+            val secondFuture =
+                executor.submit<PopularNewsletterSnapshot> {
+                    sut.rebuildGlobalRanking(endDate, 365, 20)
+                }
+
+            assertFalse(secondExecutionEnteredGa.await(200, TimeUnit.MILLISECONDS))
+
+            allowFirstExecutionToContinue.countDown()
+
+            firstFuture.get(5, TimeUnit.SECONDS)
+            secondFuture.get(5, TimeUnit.SECONDS)
+
+            assertEquals(2, gaInvocationCount.get())
+            assertEquals(2, saveInvocationCount.get())
+            assertTrue(secondExecutionEnteredGa.await(1, TimeUnit.SECONDS))
+        } finally {
+            executor.shutdownNow()
+        }
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/api/src/test/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchServiceTest.kt
+++ b/api/src/test/kotlin/com/nexters/api/batch/service/PopularNewsletterRankingBatchServiceTest.kt
@@ -1,0 +1,149 @@
+package com.nexters.api.batch.service
+
+import com.nexters.api.batch.dto.NewsletterClick
+import com.nexters.external.entity.PopularNewsletterSnapshot
+import com.nexters.external.enums.PopularNewsletterResolutionStatus
+import com.nexters.external.enums.PopularNewsletterSegmentType
+import com.nexters.external.enums.PopularNewsletterSnapshotStatus
+import com.nexters.external.service.PopularNewsletterObjectIdResolverService
+import com.nexters.external.service.PopularNewsletterObjectResolution
+import com.nexters.external.service.PopularNewsletterSnapshotService
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito
+import java.time.LocalDate
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class PopularNewsletterRankingBatchServiceTest {
+    private val googleAnalyticsService: GoogleAnalyticsService = Mockito.mock(GoogleAnalyticsService::class.java)
+    private val popularNewsletterObjectIdResolverService: PopularNewsletterObjectIdResolverService =
+        Mockito.mock(PopularNewsletterObjectIdResolverService::class.java)
+    private val popularNewsletterSnapshotService: PopularNewsletterSnapshotService =
+        Mockito.mock(PopularNewsletterSnapshotService::class.java)
+
+    private val sut =
+        PopularNewsletterRankingBatchService(
+            googleAnalyticsService = googleAnalyticsService,
+            popularNewsletterObjectIdResolverService = popularNewsletterObjectIdResolverService,
+            popularNewsletterSnapshotService = popularNewsletterSnapshotService,
+        )
+
+    @Test
+    fun `rebuildGlobalRanking should save success snapshot with resolved and unresolved items`() {
+        val endDate = LocalDate.of(2026, 4, 18)
+        var savedCommand: com.nexters.external.service.SavePopularNewsletterSnapshotCommand? = null
+        val savedSnapshot =
+            PopularNewsletterSnapshot(
+                id = 100L,
+                segmentType = PopularNewsletterSegmentType.GLOBAL,
+                windowStartDate = LocalDate.of(2025, 4, 19),
+                windowEndDate = endDate,
+                generatedAt = LocalDateTime.of(2026, 4, 18, 7, 30),
+                sourceEventName = PopularNewsletterRankingBatchService.NEWSLETTER_CLICK_EVENT_NAME,
+                candidateLimit = 20,
+                resolvedItemCount = 1,
+                status = PopularNewsletterSnapshotStatus.SUCCESS,
+            )
+
+        Mockito
+            .`when`(googleAnalyticsService.getTopNewsletterClicksForRollingWindow(endDate, 365, 20))
+            .thenReturn(
+                listOf(
+                    NewsletterClick(objectId = "11", clickCount = 120L),
+                    NewsletterClick(objectId = "unresolved-object", clickCount = 95L),
+                ),
+            )
+        Mockito
+            .`when`(popularNewsletterObjectIdResolverService.resolveObjectId("11"))
+            .thenReturn(
+                PopularNewsletterObjectResolution(
+                    resolvedContentId = 101L,
+                    resolvedExposureContentId = 11L,
+                    resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
+                ),
+            )
+        Mockito
+            .`when`(popularNewsletterObjectIdResolverService.resolveObjectId("unresolved-object"))
+            .thenReturn(
+                PopularNewsletterObjectResolution(
+                    resolutionStatus = PopularNewsletterResolutionStatus.UNRESOLVED,
+                ),
+            )
+        Mockito
+            .doAnswer { invocation ->
+                savedCommand = invocation.getArgument(0)
+                savedSnapshot
+            }.`when`(popularNewsletterSnapshotService)
+            .saveSnapshot(any())
+
+        val result = sut.rebuildGlobalRanking(endDate, 365, 20)
+
+        assertSame(savedSnapshot, result)
+
+        val command = assertNotNull(savedCommand)
+        assertEquals(PopularNewsletterSegmentType.GLOBAL, command.segmentType)
+        assertEquals(LocalDate.of(2025, 4, 19), command.windowStartDate)
+        assertEquals(endDate, command.windowEndDate)
+        assertEquals(PopularNewsletterRankingBatchService.NEWSLETTER_CLICK_EVENT_NAME, command.sourceEventName)
+        assertEquals(20, command.candidateLimit)
+        assertEquals(1, command.resolvedItemCount)
+        assertEquals(PopularNewsletterSnapshotStatus.SUCCESS, command.status)
+        assertEquals(2, command.items.size)
+        assertEquals(1, command.items[0].rank)
+        assertEquals("11", command.items[0].rawObjectId)
+        assertEquals(120L, command.items[0].clickCount)
+        assertEquals(11L, command.items[0].resolvedExposureContentId)
+        assertEquals(PopularNewsletterResolutionStatus.RESOLVED, command.items[0].resolutionStatus)
+        assertEquals(2, command.items[1].rank)
+        assertEquals("unresolved-object", command.items[1].rawObjectId)
+        assertEquals(PopularNewsletterResolutionStatus.UNRESOLVED, command.items[1].resolutionStatus)
+    }
+
+    @Test
+    fun `rebuildGlobalRanking should save failed snapshot and throw when ga query fails`() {
+        val endDate = LocalDate.of(2026, 4, 18)
+        var savedCommand: com.nexters.external.service.SavePopularNewsletterSnapshotCommand? = null
+
+        Mockito
+            .`when`(googleAnalyticsService.getTopNewsletterClicksForRollingWindow(endDate, 365, 20))
+            .thenThrow(RuntimeException("GA error"))
+        Mockito
+            .doAnswer { invocation ->
+                savedCommand = invocation.getArgument(0)
+                PopularNewsletterSnapshot(
+                    id = 101L,
+                    segmentType = PopularNewsletterSegmentType.GLOBAL,
+                    windowStartDate = LocalDate.of(2025, 4, 19),
+                    windowEndDate = endDate,
+                    generatedAt = LocalDateTime.of(2026, 4, 18, 7, 30),
+                    sourceEventName = PopularNewsletterRankingBatchService.NEWSLETTER_CLICK_EVENT_NAME,
+                    candidateLimit = 20,
+                    resolvedItemCount = 0,
+                    status = PopularNewsletterSnapshotStatus.FAILED,
+                )
+            }.`when`(popularNewsletterSnapshotService)
+            .saveSnapshot(any())
+
+        val exception =
+            assertThrows<IllegalStateException> {
+                sut.rebuildGlobalRanking(endDate, 365, 20)
+            }
+
+        assertTrue(exception.message!!.contains("인기 뉴스레터 랭킹 스냅샷 생성"))
+
+        val command = assertNotNull(savedCommand)
+        assertEquals(PopularNewsletterSnapshotStatus.FAILED, command.status)
+        assertEquals(0, command.resolvedItemCount)
+        assertTrue(command.items.isEmpty())
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> any(): T {
+        Mockito.any<T>()
+        return null as T
+    }
+}

--- a/api/src/test/kotlin/com/nexters/api/controller/NewsletterApiControllerTest.kt
+++ b/api/src/test/kotlin/com/nexters/api/controller/NewsletterApiControllerTest.kt
@@ -17,6 +17,7 @@ import com.nexters.external.service.PopularNewsletterSnapshotService
 import com.nexters.newsletter.resolver.DailyContentArchiveResolver
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
@@ -144,10 +145,10 @@ class NewsletterApiControllerTest {
                 summaryContent = "인기 글 요약",
             )
 
-        org.mockito.Mockito
+        Mockito
             .`when`(dayArchiveResolver.resolveTodayContentArchive(1L, publishedDate))
             .thenReturn(archive)
-        org.mockito.Mockito
+        Mockito
             .`when`(popularNewsletterSnapshotService.findLatestFeaturedExposureContent())
             .thenReturn(featuredExposureContent)
 
@@ -217,10 +218,10 @@ class NewsletterApiControllerTest {
                     ),
             )
 
-        org.mockito.Mockito
+        Mockito
             .`when`(dayArchiveResolver.resolveTodayContentArchive(1L, publishedDate))
             .thenReturn(archive)
-        org.mockito.Mockito
+        Mockito
             .`when`(popularNewsletterSnapshotService.findLatestFeaturedExposureContent())
             .thenReturn(null)
 
@@ -268,10 +269,10 @@ class NewsletterApiControllerTest {
             )
 
         // When & Then
-        org.mockito.Mockito
+        Mockito
             .`when`(tokenUtil.validateAndGetEmail(validToken))
             .thenReturn("admin@example.com")
-        org.mockito.Mockito
+        Mockito
             .`when`(
                 contentService.createContent(
                     title = request.title,
@@ -332,7 +333,7 @@ class NewsletterApiControllerTest {
         val invalidToken = "invalid_token"
 
         // When & Then
-        org.mockito.Mockito
+        Mockito
             .`when`(tokenUtil.validateAndGetEmail(invalidToken))
             .thenThrow(IllegalArgumentException("Invalid token"))
 
@@ -379,10 +380,10 @@ class NewsletterApiControllerTest {
             )
 
         // When & Then
-        org.mockito.Mockito
+        Mockito
             .`when`(tokenUtil.validateAndGetEmail(validToken))
             .thenReturn("admin@example.com")
-        org.mockito.Mockito
+        Mockito
             .`when`(
                 contentService.createContent(
                     title = request.title,

--- a/api/src/test/kotlin/com/nexters/api/controller/NewsletterApiControllerTest.kt
+++ b/api/src/test/kotlin/com/nexters/api/controller/NewsletterApiControllerTest.kt
@@ -2,23 +2,29 @@ package com.nexters.api.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nexters.api.dto.CreateContentApiRequest
+import com.nexters.api.service.NewsletterContentsService
 import com.nexters.api.util.TokenUtil
 import com.nexters.external.entity.AdminMember
 import com.nexters.external.entity.Content
 import com.nexters.external.entity.ContentProvider
+import com.nexters.external.entity.DailyContentArchive
+import com.nexters.external.entity.ExposureContent
 import com.nexters.external.repository.AdminMemberRepository
 import com.nexters.external.service.ContentProviderRequestService
 import com.nexters.external.service.ContentService
 import com.nexters.external.service.ExposureContentService
+import com.nexters.external.service.PopularNewsletterSnapshotService
 import com.nexters.newsletter.resolver.DailyContentArchiveResolver
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -27,6 +33,7 @@ import java.time.LocalDateTime
 import java.util.Base64
 
 @WebMvcTest(NewsletterApiController::class)
+@Import(NewsletterContentsService::class)
 @ActiveProfiles("test")
 class NewsletterApiControllerTest {
     @Autowired
@@ -40,6 +47,9 @@ class NewsletterApiControllerTest {
 
     @MockitoBean
     private lateinit var exposureContentService: ExposureContentService
+
+    @MockitoBean
+    private lateinit var popularNewsletterSnapshotService: PopularNewsletterSnapshotService
 
     @MockitoBean
     private lateinit var contentService: ContentService
@@ -65,6 +75,165 @@ class NewsletterApiControllerTest {
                 name = "Admin User"
             )
         validToken = Base64.getEncoder().encodeToString("admin@example.com:token".toByteArray())
+    }
+
+    @Test
+    fun `should return featured trending card from snapshot in v1 response`() {
+        val publishedDate = LocalDate.of(2025, 7, 8)
+        val archive =
+            DailyContentArchive(
+                date = publishedDate,
+                user =
+                    DailyContentArchive.UserSnapshot(
+                        id = 1L,
+                        deviceToken = "device-token",
+                        createdAt = LocalDateTime.of(2025, 7, 8, 0, 0),
+                        updatedAt = LocalDateTime.of(2025, 7, 8, 0, 0),
+                    ),
+                exposureContents =
+                    listOf(
+                        ExposureContent(
+                            id = 11L,
+                            content =
+                                Content(
+                                    id = 101L,
+                                    title = "원문 제목",
+                                    content = "원문 본문",
+                                    newsletterName = "안드로이드 위클리",
+                                    originalUrl = "https://example.com/article-1",
+                                    imageUrl = "https://example.com/image-1.png",
+                                    publishedAt = publishedDate,
+                                    contentProvider =
+                                        ContentProvider(
+                                            id = 201L,
+                                            name = "Android Weekly",
+                                            channel = "android-weekly",
+                                            language = "ko",
+                                            type = null,
+                                        ),
+                                ),
+                            provocativeKeyword = "Kotlin",
+                            provocativeHeadline = "후킹 제목",
+                            summaryContent = "요약 내용",
+                        ),
+                    ),
+            )
+        val featuredExposureContent =
+            ExposureContent(
+                id = 99L,
+                content =
+                    Content(
+                        id = 199L,
+                        title = "인기 원문 제목",
+                        content = "인기 원문 본문",
+                        newsletterName = "프론트엔드 위클리",
+                        originalUrl = "https://example.com/featured-article",
+                        imageUrl = "https://example.com/featured-image.png",
+                        publishedAt = publishedDate.minusDays(1),
+                        contentProvider =
+                            ContentProvider(
+                                id = 299L,
+                                name = "Frontend Weekly",
+                                channel = "frontend-weekly",
+                                language = "en",
+                                type = null,
+                            ),
+                    ),
+                provocativeKeyword = "React",
+                provocativeHeadline = "가장 많이 읽힌 글",
+                summaryContent = "인기 글 요약",
+            )
+
+        org.mockito.Mockito
+            .`when`(dayArchiveResolver.resolveTodayContentArchive(1L, publishedDate))
+            .thenReturn(archive)
+        org.mockito.Mockito
+            .`when`(popularNewsletterSnapshotService.findLatestFeaturedExposureContent())
+            .thenReturn(featuredExposureContent)
+
+        mockMvc
+            .perform(
+                get("/api/newsletters/contents/1")
+                    .param("publishedDate", publishedDate.toString()),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.publishedDate").value("2025-07-08"))
+            .andExpect(jsonPath("$.trendingCard.id").value(99L))
+            .andExpect(jsonPath("$.trendingCard.title").value("가장 많이 읽힌 글"))
+            .andExpect(jsonPath("$.trendingCard.topKeyword").value("React"))
+            .andExpect(jsonPath("$.trendingCard.summary").value("인기 글 요약"))
+            .andExpect(jsonPath("$.trendingCard.contentUrl").value("https://example.com/featured-article"))
+            .andExpect(jsonPath("$.trendingCard.imageUrl").value("https://example.com/featured-image.png"))
+            .andExpect(jsonPath("$.trendingCard.newsletterName").value("프론트엔드 위클리"))
+            .andExpect(jsonPath("$.trendingCard.language").value("ENGLISH"))
+            .andExpect(jsonPath("$.cards[0].id").value(11L))
+            .andExpect(jsonPath("$.cards[0].title").value("후킹 제목"))
+            .andExpect(jsonPath("$.cards[0].topKeyword").value("Kotlin"))
+            .andExpect(jsonPath("$.cards[0].summary").value("요약 내용"))
+            .andExpect(jsonPath("$.cards[0].contentUrl").value("https://example.com/article-1"))
+            .andExpect(jsonPath("$.cards[0].imageUrl").value("https://example.com/image-1.png"))
+            .andExpect(jsonPath("$.cards[0].newsletterName").value("안드로이드 위클리"))
+            .andExpect(jsonPath("$.cards[0].language").value("KOREAN"))
+    }
+
+    @Test
+    fun `should fallback featured trending card to first card in v1 response`() {
+        val publishedDate = LocalDate.of(2025, 7, 8)
+        val archive =
+            DailyContentArchive(
+                date = publishedDate,
+                user =
+                    DailyContentArchive.UserSnapshot(
+                        id = 1L,
+                        deviceToken = "device-token",
+                        createdAt = LocalDateTime.of(2025, 7, 8, 0, 0),
+                        updatedAt = LocalDateTime.of(2025, 7, 8, 0, 0),
+                    ),
+                exposureContents =
+                    listOf(
+                        ExposureContent(
+                            id = 11L,
+                            content =
+                                Content(
+                                    id = 101L,
+                                    title = "원문 제목",
+                                    content = "원문 본문",
+                                    newsletterName = "안드로이드 위클리",
+                                    originalUrl = "https://example.com/article-1",
+                                    imageUrl = "https://example.com/image-1.png",
+                                    publishedAt = publishedDate,
+                                    contentProvider =
+                                        ContentProvider(
+                                            id = 201L,
+                                            name = "Android Weekly",
+                                            channel = "android-weekly",
+                                            language = "ko",
+                                            type = null,
+                                        ),
+                                ),
+                            provocativeKeyword = "Kotlin",
+                            provocativeHeadline = "후킹 제목",
+                            summaryContent = "요약 내용",
+                        ),
+                    ),
+            )
+
+        org.mockito.Mockito
+            .`when`(dayArchiveResolver.resolveTodayContentArchive(1L, publishedDate))
+            .thenReturn(archive)
+        org.mockito.Mockito
+            .`when`(popularNewsletterSnapshotService.findLatestFeaturedExposureContent())
+            .thenReturn(null)
+
+        mockMvc
+            .perform(
+                get("/api/newsletters/contents/1")
+                    .param("publishedDate", publishedDate.toString()),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.publishedDate").value("2025-07-08"))
+            .andExpect(jsonPath("$.trendingCard.id").value(11L))
+            .andExpect(jsonPath("$.trendingCard.title").value("후킹 제목"))
+            .andExpect(jsonPath("$.trendingCard.topKeyword").value("Kotlin"))
+            .andExpect(jsonPath("$.cards[0].id").value(11L))
     }
 
     @Test

--- a/external/src/main/kotlin/com/nexters/external/entity/Content.kt
+++ b/external/src/main/kotlin/com/nexters/external/entity/Content.kt
@@ -23,15 +23,15 @@ class Content(
     val id: Long? = null,
     @Column(nullable = true, name = "newsletter_source_id")
     val newsletterSourceId: String? = null,
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     val title: String,
     @Column(nullable = false, columnDefinition = "TEXT")
     val content: String,
-    @Column(nullable = false, name = "newsletter_name")
+    @Column(nullable = false, name = "newsletter_name", columnDefinition = "TEXT")
     val newsletterName: String,
-    @Column(nullable = false, name = "original_url")
+    @Column(nullable = false, name = "original_url", columnDefinition = "TEXT")
     val originalUrl: String,
-    @Column(nullable = true, name = "image_url")
+    @Column(nullable = true, name = "image_url", columnDefinition = "TEXT")
     val imageUrl: String? = null,
     @Column(nullable = true, name = "published_at")
     val publishedAt: LocalDate,

--- a/external/src/main/kotlin/com/nexters/external/entity/PopularNewsletterSnapshot.kt
+++ b/external/src/main/kotlin/com/nexters/external/entity/PopularNewsletterSnapshot.kt
@@ -1,0 +1,63 @@
+package com.nexters.external.entity
+
+import com.nexters.external.enums.PopularNewsletterSegmentType
+import com.nexters.external.enums.PopularNewsletterSnapshotStatus
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import org.hibernate.annotations.Comment
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Entity
+@Comment("인기 뉴스레터 랭킹 스냅샷 메타데이터")
+@Table(
+    name = "popular_newsletter_snapshots",
+    indexes = [
+        Index(
+            name = "idx_popular_newsletter_snapshot_segment_generated_at",
+            columnList = "segment_type, segment_key, generated_at",
+        ),
+    ],
+)
+class PopularNewsletterSnapshot(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("스냅샷 식별자")
+    val id: Long? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "segment_type", nullable = false, length = 20)
+    @Comment("랭킹 집계 세그먼트 유형")
+    val segmentType: PopularNewsletterSegmentType,
+    @Column(name = "segment_key")
+    @Comment("세그먼트 상세 키")
+    val segmentKey: String? = null,
+    @Column(name = "window_start_date", nullable = false)
+    @Comment("랭킹 집계 시작일")
+    val windowStartDate: LocalDate,
+    @Column(name = "window_end_date", nullable = false)
+    @Comment("랭킹 집계 종료일")
+    val windowEndDate: LocalDate,
+    @Column(name = "generated_at", nullable = false)
+    @Comment("랭킹 스냅샷 생성 시각")
+    val generatedAt: LocalDateTime = LocalDateTime.now(),
+    @Column(name = "source_event_name", nullable = false)
+    @Comment("랭킹 집계에 사용한 이벤트 이름")
+    val sourceEventName: String,
+    @Column(name = "candidate_limit", nullable = false)
+    @Comment("랭킹 후보 최대 개수")
+    val candidateLimit: Int,
+    @Column(name = "resolved_item_count", nullable = false)
+    @Comment("실제 콘텐츠로 해석된 아이템 수")
+    val resolvedItemCount: Int,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Comment("스냅샷 생성 결과 상태")
+    val status: PopularNewsletterSnapshotStatus,
+)

--- a/external/src/main/kotlin/com/nexters/external/entity/PopularNewsletterSnapshot.kt
+++ b/external/src/main/kotlin/com/nexters/external/entity/PopularNewsletterSnapshot.kt
@@ -24,6 +24,10 @@ import java.time.LocalDateTime
             name = "idx_popular_newsletter_snapshot_segment_generated_at",
             columnList = "segment_type, segment_key, generated_at",
         ),
+        Index(
+            name = "idx_popular_newsletter_snapshot_segment_status_generated_at",
+            columnList = "segment_type, status, segment_key, generated_at",
+        ),
     ],
 )
 class PopularNewsletterSnapshot(
@@ -56,6 +60,9 @@ class PopularNewsletterSnapshot(
     @Column(name = "resolved_item_count", nullable = false)
     @Comment("실제 콘텐츠로 해석된 아이템 수")
     val resolvedItemCount: Int,
+    @Column(name = "featured_exposure_content_id")
+    @Comment("대표로 노출할 exposure content id")
+    val featuredExposureContentId: Long? = null,
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     @Comment("스냅샷 생성 결과 상태")

--- a/external/src/main/kotlin/com/nexters/external/entity/PopularNewsletterSnapshotItem.kt
+++ b/external/src/main/kotlin/com/nexters/external/entity/PopularNewsletterSnapshotItem.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.Index
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
@@ -19,6 +20,12 @@ import java.time.LocalDateTime
 @Comment("인기 뉴스레터 스냅샷 개별 랭킹 아이템")
 @Table(
     name = "popular_newsletter_snapshot_items",
+    indexes = [
+        Index(
+            name = "idx_popular_newsletter_snapshot_items_snapshot_resolution_rank",
+            columnList = "snapshot_id, resolution_status, rank_order",
+        ),
+    ],
     uniqueConstraints = [
         UniqueConstraint(
             name = "uk_popular_newsletter_snapshot_item_snapshot_rank",

--- a/external/src/main/kotlin/com/nexters/external/entity/PopularNewsletterSnapshotItem.kt
+++ b/external/src/main/kotlin/com/nexters/external/entity/PopularNewsletterSnapshotItem.kt
@@ -1,0 +1,60 @@
+package com.nexters.external.entity
+
+import com.nexters.external.enums.PopularNewsletterResolutionStatus
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.Comment
+import java.time.LocalDateTime
+
+@Entity
+@Comment("인기 뉴스레터 스냅샷 개별 랭킹 아이템")
+@Table(
+    name = "popular_newsletter_snapshot_items",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_popular_newsletter_snapshot_item_snapshot_rank",
+            columnNames = ["snapshot_id", "rank_order"],
+        ),
+    ],
+)
+class PopularNewsletterSnapshotItem(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    @ManyToOne(fetch = FetchType.EAGER)
+    val snapshot: PopularNewsletterSnapshot,
+    @Column(name = "rank_order", nullable = false)
+    @Comment("랭킹 순위")
+    val rank: Int,
+    @Column(name = "raw_object_id", nullable = false)
+    @Comment("GA 이벤트에 실려 올라온 raw한 object_id")
+    val rawObjectId: String,
+    @Column(name = "click_count", nullable = false)
+    @Comment("집계된 클릭 수")
+    val clickCount: Long,
+    @Column(name = "resolved_content_id")
+    @Comment("해석된 콘텐츠 id")
+    val resolvedContentId: Long? = null,
+    @Column(name = "resolved_exposure_content_id")
+    @Comment("해석된 노출 콘텐츠 id")
+    val resolvedExposureContentId: Long? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "resolution_status", nullable = false, length = 20)
+    @Comment("object id 해석 상태")
+    val resolutionStatus: PopularNewsletterResolutionStatus,
+    @Column(nullable = false, name = "created_at")
+    @Comment("레코드 생성 시각")
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    @Column(nullable = false, name = "updated_at")
+    @Comment("레코드 수정 시각")
+    val updatedAt: LocalDateTime = LocalDateTime.now()
+)

--- a/external/src/main/kotlin/com/nexters/external/entity/RssProcessingStatus.kt
+++ b/external/src/main/kotlin/com/nexters/external/entity/RssProcessingStatus.kt
@@ -16,11 +16,11 @@ class RssProcessingStatus(
     val id: Long? = null,
     @Column(name = "newsletter_source_id", unique = true, nullable = false)
     val newsletterSourceId: String,
-    @Column(name = "rss_url", nullable = false)
+    @Column(name = "rss_url", nullable = false, columnDefinition = "TEXT")
     val rssUrl: String,
-    @Column(name = "item_url", unique = true, nullable = false)
+    @Column(name = "item_url", unique = true, nullable = false, columnDefinition = "TEXT")
     val itemUrl: String,
-    @Column(name = "title", nullable = false)
+    @Column(name = "title", nullable = false, columnDefinition = "TEXT")
     val title: String,
     @Column(name = "is_processed", nullable = false)
     var isProcessed: Boolean = false,

--- a/external/src/main/kotlin/com/nexters/external/enums/PopularNewsletterResolutionStatus.kt
+++ b/external/src/main/kotlin/com/nexters/external/enums/PopularNewsletterResolutionStatus.kt
@@ -1,0 +1,6 @@
+package com.nexters.external.enums
+
+enum class PopularNewsletterResolutionStatus {
+    RESOLVED,
+    UNRESOLVED,
+}

--- a/external/src/main/kotlin/com/nexters/external/enums/PopularNewsletterSegmentType.kt
+++ b/external/src/main/kotlin/com/nexters/external/enums/PopularNewsletterSegmentType.kt
@@ -1,0 +1,7 @@
+package com.nexters.external.enums
+
+enum class PopularNewsletterSegmentType {
+    GLOBAL,
+    CATEGORY,
+    JOB_GROUP,
+}

--- a/external/src/main/kotlin/com/nexters/external/enums/PopularNewsletterSnapshotStatus.kt
+++ b/external/src/main/kotlin/com/nexters/external/enums/PopularNewsletterSnapshotStatus.kt
@@ -1,0 +1,6 @@
+package com.nexters.external.enums
+
+enum class PopularNewsletterSnapshotStatus {
+    SUCCESS,
+    FAILED,
+}

--- a/external/src/main/kotlin/com/nexters/external/filter/FilterChain.kt
+++ b/external/src/main/kotlin/com/nexters/external/filter/FilterChain.kt
@@ -1,6 +1,7 @@
 package com.nexters.external.filter
 
 import com.nexters.external.entity.Content
+import com.nexters.external.enums.ContentProviderType
 import org.slf4j.LoggerFactory
 
 /**
@@ -65,7 +66,7 @@ class FilterChain(
             filters.add(LengthFilter(minLength, maxLength))
         }
 
-        fun addProviderTypeFilter(vararg types: com.nexters.external.enums.ContentProviderType) =
+        fun addProviderTypeFilter(vararg types: ContentProviderType) =
             apply {
                 filters.add(ProviderTypeFilter(types.toSet()))
             }

--- a/external/src/main/kotlin/com/nexters/external/repository/CategoryRepository.kt
+++ b/external/src/main/kotlin/com/nexters/external/repository/CategoryRepository.kt
@@ -2,6 +2,7 @@ package com.nexters.external.repository
 
 import com.nexters.external.entity.Category
 import com.nexters.external.entity.CategoryKeywordMapping
+import com.nexters.external.entity.ContentProvider
 import com.nexters.external.entity.ReservedKeyword
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -57,5 +58,5 @@ interface CategoryRepository : JpaRepository<Category, Long> {
         WHERE cpcm.category.id IN (:categoryIds)
     """,
     )
-    fun findContentProvidersByCategoryIds(categoryIds: List<Long>): List<com.nexters.external.entity.ContentProvider>
+    fun findContentProvidersByCategoryIds(categoryIds: List<Long>): List<ContentProvider>
 }

--- a/external/src/main/kotlin/com/nexters/external/repository/ContentRepository.kt
+++ b/external/src/main/kotlin/com/nexters/external/repository/ContentRepository.kt
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.time.LocalDate
 
 interface ContentRepository : JpaRepository<Content, Long> {
     @Query(
@@ -116,14 +117,64 @@ interface ContentRepository : JpaRepository<Content, Long> {
         pageable: Pageable
     ): Page<Content>
 
+    @Query(
+        """
+        SELECT new com.nexters.external.repository.ContentLookupRow(
+            c.id,
+            c.originalUrl,
+            c.newsletterSourceId,
+            c.publishedAt
+        )
+        FROM Content c
+        WHERE c.id IN :contentIds
+    """,
+    )
+    fun findLookupRowsByIds(
+        @Param("contentIds") contentIds: Collection<Long>,
+    ): List<ContentLookupRow>
+
+    @Query(
+        """
+        SELECT new com.nexters.external.repository.ContentLookupRow(
+            c.id,
+            c.originalUrl,
+            c.newsletterSourceId,
+            c.publishedAt
+        )
+        FROM Content c
+        WHERE c.originalUrl IN :originalUrls
+        ORDER BY c.originalUrl ASC, c.publishedAt DESC, c.id DESC
+    """,
+    )
+    fun findLookupRowsByOriginalUrls(
+        @Param("originalUrls") originalUrls: Collection<String>,
+    ): List<ContentLookupRow>
+
+    @Query(
+        """
+        SELECT new com.nexters.external.repository.ContentLookupRow(
+            c.id,
+            c.originalUrl,
+            c.newsletterSourceId,
+            c.publishedAt
+        )
+        FROM Content c
+        WHERE c.newsletterSourceId IN :newsletterSourceIds
+        ORDER BY c.newsletterSourceId ASC, c.publishedAt DESC, c.id DESC
+    """,
+    )
+    fun findLookupRowsByNewsletterSourceIds(
+        @Param("newsletterSourceIds") newsletterSourceIds: Collection<String>,
+    ): List<ContentLookupRow>
+
     // RSS 피드용 메서드들
     fun findByOriginalUrl(originalUrl: String): Content?
 
     fun findByNewsletterName(newsletterName: String): List<Content>
 
     fun findByPublishedAtBetween(
-        startDate: java.time.LocalDate,
-        endDate: java.time.LocalDate
+        startDate: LocalDate,
+        endDate: LocalDate
     ): List<Content>
 
     fun existsByNewsletterSourceId(newsletterSourceId: String): Boolean

--- a/external/src/main/kotlin/com/nexters/external/repository/ExposureContentRepository.kt
+++ b/external/src/main/kotlin/com/nexters/external/repository/ExposureContentRepository.kt
@@ -15,6 +15,34 @@ interface ExposureContentRepository : JpaRepository<ExposureContent, Long> {
 
     fun findByContentId(contentId: Long): ExposureContent?
 
+    @Query(
+        """
+        SELECT new com.nexters.external.repository.ExposureContentLookupRow(
+            e.id,
+            e.content.id
+        )
+        FROM ExposureContent e
+        WHERE e.id IN :exposureContentIds
+    """,
+    )
+    fun findLookupRowsByIds(
+        @Param("exposureContentIds") exposureContentIds: Collection<Long>,
+    ): List<ExposureContentLookupRow>
+
+    @Query(
+        """
+        SELECT new com.nexters.external.repository.ExposureContentLookupRow(
+            e.id,
+            e.content.id
+        )
+        FROM ExposureContent e
+        WHERE e.content.id IN :contentIds
+    """,
+    )
+    fun findLookupRowsByContentIds(
+        @Param("contentIds") contentIds: Collection<Long>,
+    ): List<ExposureContentLookupRow>
+
     // 모든 ExposureContent를 페이징으로 조회
     @Query(
         """

--- a/external/src/main/kotlin/com/nexters/external/repository/ExposureContentRepository.kt
+++ b/external/src/main/kotlin/com/nexters/external/repository/ExposureContentRepository.kt
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Repository
 interface ExposureContentRepository : JpaRepository<ExposureContent, Long> {
     fun findByContent(content: Content): ExposureContent?
 
+    fun findByContentId(contentId: Long): ExposureContent?
+
     // 모든 ExposureContent를 페이징으로 조회
     @Query(
         """

--- a/external/src/main/kotlin/com/nexters/external/repository/PopularNewsletterLookupRows.kt
+++ b/external/src/main/kotlin/com/nexters/external/repository/PopularNewsletterLookupRows.kt
@@ -1,0 +1,15 @@
+package com.nexters.external.repository
+
+import java.time.LocalDate
+
+data class ContentLookupRow(
+    val id: Long,
+    val originalUrl: String,
+    val newsletterSourceId: String?,
+    val publishedAt: LocalDate?,
+)
+
+data class ExposureContentLookupRow(
+    val id: Long,
+    val contentId: Long,
+)

--- a/external/src/main/kotlin/com/nexters/external/repository/PopularNewsletterSnapshotItemRepository.kt
+++ b/external/src/main/kotlin/com/nexters/external/repository/PopularNewsletterSnapshotItemRepository.kt
@@ -1,0 +1,14 @@
+package com.nexters.external.repository
+
+import com.nexters.external.entity.PopularNewsletterSnapshotItem
+import com.nexters.external.enums.PopularNewsletterResolutionStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PopularNewsletterSnapshotItemRepository : JpaRepository<PopularNewsletterSnapshotItem, Long> {
+    fun findFirstBySnapshotIdAndResolutionStatusOrderByRankAsc(
+        snapshotId: Long,
+        resolutionStatus: PopularNewsletterResolutionStatus,
+    ): PopularNewsletterSnapshotItem?
+}

--- a/external/src/main/kotlin/com/nexters/external/repository/PopularNewsletterSnapshotRepository.kt
+++ b/external/src/main/kotlin/com/nexters/external/repository/PopularNewsletterSnapshotRepository.kt
@@ -3,6 +3,7 @@ package com.nexters.external.repository
 import com.nexters.external.entity.PopularNewsletterSnapshot
 import com.nexters.external.enums.PopularNewsletterSegmentType
 import com.nexters.external.enums.PopularNewsletterSnapshotStatus
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -24,5 +25,23 @@ interface PopularNewsletterSnapshotRepository : JpaRepository<PopularNewsletterS
         @Param("segmentType") segmentType: PopularNewsletterSegmentType,
         @Param("segmentKey") segmentKey: String?,
         @Param("status") status: PopularNewsletterSnapshotStatus,
+    ): List<PopularNewsletterSnapshot>
+
+    @Query(
+        """
+        SELECT s
+        FROM PopularNewsletterSnapshot s
+        WHERE s.segmentType = :segmentType
+        AND s.status = :status
+        AND s.featuredExposureContentId IS NOT NULL
+        AND ((:segmentKey IS NULL AND s.segmentKey IS NULL) OR s.segmentKey = :segmentKey)
+        ORDER BY s.generatedAt DESC
+        """,
+    )
+    fun findLatestFeaturedBySegmentTypeAndSegmentKeyAndStatus(
+        @Param("segmentType") segmentType: PopularNewsletterSegmentType,
+        @Param("segmentKey") segmentKey: String?,
+        @Param("status") status: PopularNewsletterSnapshotStatus,
+        pageable: Pageable,
     ): List<PopularNewsletterSnapshot>
 }

--- a/external/src/main/kotlin/com/nexters/external/repository/PopularNewsletterSnapshotRepository.kt
+++ b/external/src/main/kotlin/com/nexters/external/repository/PopularNewsletterSnapshotRepository.kt
@@ -1,0 +1,28 @@
+package com.nexters.external.repository
+
+import com.nexters.external.entity.PopularNewsletterSnapshot
+import com.nexters.external.enums.PopularNewsletterSegmentType
+import com.nexters.external.enums.PopularNewsletterSnapshotStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PopularNewsletterSnapshotRepository : JpaRepository<PopularNewsletterSnapshot, Long> {
+    @Query(
+        """
+        SELECT s
+        FROM PopularNewsletterSnapshot s
+        WHERE s.segmentType = :segmentType
+        AND s.status = :status
+        AND ((:segmentKey IS NULL AND s.segmentKey IS NULL) OR s.segmentKey = :segmentKey)
+        ORDER BY s.generatedAt DESC
+        """,
+    )
+    fun findBySegmentTypeAndSegmentKeyAndStatusOrderByGeneratedAtDesc(
+        @Param("segmentType") segmentType: PopularNewsletterSegmentType,
+        @Param("segmentKey") segmentKey: String?,
+        @Param("status") status: PopularNewsletterSnapshotStatus,
+    ): List<PopularNewsletterSnapshot>
+}

--- a/external/src/main/kotlin/com/nexters/external/service/PopularNewsletterObjectIdResolverService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/PopularNewsletterObjectIdResolverService.kt
@@ -1,0 +1,86 @@
+package com.nexters.external.service
+
+import com.nexters.external.enums.PopularNewsletterResolutionStatus
+import com.nexters.external.repository.ContentRepository
+import com.nexters.external.repository.ExposureContentRepository
+import org.springframework.stereotype.Service
+
+@Service
+class PopularNewsletterObjectIdResolverService(
+    private val contentRepository: ContentRepository,
+    private val exposureContentRepository: ExposureContentRepository,
+) {
+    fun resolveObjectId(rawObjectId: String): PopularNewsletterObjectResolution {
+        rawObjectId.toLongOrNull()?.let { numericId ->
+            exposureContentRepository.findById(numericId).orElse(null)?.let { exposureContent ->
+                return PopularNewsletterObjectResolution(
+                    resolvedContentId = exposureContent.content.id,
+                    resolvedExposureContentId = exposureContent.id,
+                    resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
+                )
+            }
+
+            contentRepository.findById(numericId).orElse(null)?.let { content ->
+                val exposureContent = exposureContentRepository.findByContentId(content.id!!)
+                return PopularNewsletterObjectResolution(
+                    resolvedContentId = content.id,
+                    resolvedExposureContentId = exposureContent?.id,
+                    resolutionStatus =
+                        if (exposureContent != null) {
+                            PopularNewsletterResolutionStatus.RESOLVED
+                        } else {
+                            PopularNewsletterResolutionStatus.UNRESOLVED
+                        },
+                )
+            }
+        }
+
+        contentRepository.findByOriginalUrl(rawObjectId)?.let { content ->
+            val exposureContent = exposureContentRepository.findByContentId(content.id!!)
+            return PopularNewsletterObjectResolution(
+                resolvedContentId = content.id,
+                resolvedExposureContentId = exposureContent?.id,
+                resolutionStatus =
+                    if (exposureContent != null) {
+                        PopularNewsletterResolutionStatus.RESOLVED
+                    } else {
+                        PopularNewsletterResolutionStatus.UNRESOLVED
+                    },
+            )
+        }
+
+        val newsletterSourceMatches =
+            contentRepository
+                .findByNewsletterSourceId(rawObjectId)
+                .sortedWith(compareByDescending<com.nexters.external.entity.Content> { it.publishedAt }.thenByDescending { it.id ?: 0L })
+
+        if (newsletterSourceMatches.isNotEmpty()) {
+            val resolvedMatch =
+                newsletterSourceMatches.firstOrNull { matchedContent ->
+                    matchedContent.id != null && exposureContentRepository.findByContentId(matchedContent.id) != null
+                } ?: newsletterSourceMatches.first()
+
+            val exposureContent = exposureContentRepository.findByContentId(resolvedMatch.id!!)
+            return PopularNewsletterObjectResolution(
+                resolvedContentId = resolvedMatch.id,
+                resolvedExposureContentId = exposureContent?.id,
+                resolutionStatus =
+                    if (exposureContent != null) {
+                        PopularNewsletterResolutionStatus.RESOLVED
+                    } else {
+                        PopularNewsletterResolutionStatus.UNRESOLVED
+                    },
+            )
+        }
+
+        return PopularNewsletterObjectResolution(
+            resolutionStatus = PopularNewsletterResolutionStatus.UNRESOLVED,
+        )
+    }
+}
+
+data class PopularNewsletterObjectResolution(
+    val resolvedContentId: Long? = null,
+    val resolvedExposureContentId: Long? = null,
+    val resolutionStatus: PopularNewsletterResolutionStatus,
+)

--- a/external/src/main/kotlin/com/nexters/external/service/PopularNewsletterObjectIdResolverService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/PopularNewsletterObjectIdResolverService.kt
@@ -1,7 +1,9 @@
 package com.nexters.external.service
 
 import com.nexters.external.enums.PopularNewsletterResolutionStatus
+import com.nexters.external.repository.ContentLookupRow
 import com.nexters.external.repository.ContentRepository
+import com.nexters.external.repository.ExposureContentLookupRow
 import com.nexters.external.repository.ExposureContentRepository
 import org.springframework.stereotype.Service
 
@@ -10,73 +12,185 @@ class PopularNewsletterObjectIdResolverService(
     private val contentRepository: ContentRepository,
     private val exposureContentRepository: ExposureContentRepository,
 ) {
-    fun resolveObjectId(rawObjectId: String): PopularNewsletterObjectResolution {
-        rawObjectId.toLongOrNull()?.let { numericId ->
-            exposureContentRepository.findById(numericId).orElse(null)?.let { exposureContent ->
-                return PopularNewsletterObjectResolution(
-                    resolvedContentId = exposureContent.content.id,
-                    resolvedExposureContentId = exposureContent.id,
-                    resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
-                )
-            }
+    fun resolveObjectId(rawObjectId: String): PopularNewsletterObjectResolution =
+        resolveObjectIds(listOf(rawObjectId))[rawObjectId] ?: unresolvedResolution()
 
-            contentRepository.findById(numericId).orElse(null)?.let { content ->
-                val exposureContent = exposureContentRepository.findByContentId(content.id!!)
-                return PopularNewsletterObjectResolution(
-                    resolvedContentId = content.id,
-                    resolvedExposureContentId = exposureContent?.id,
-                    resolutionStatus =
-                        if (exposureContent != null) {
-                            PopularNewsletterResolutionStatus.RESOLVED
-                        } else {
-                            PopularNewsletterResolutionStatus.UNRESOLVED
-                        },
-                )
-            }
+    fun resolveObjectIds(rawObjectIds: List<String>): Map<String, PopularNewsletterObjectResolution> {
+        if (rawObjectIds.isEmpty()) {
+            return emptyMap()
         }
 
-        contentRepository.findByOriginalUrl(rawObjectId)?.let { content ->
-            val exposureContent = exposureContentRepository.findByContentId(content.id!!)
-            return PopularNewsletterObjectResolution(
-                resolvedContentId = content.id,
-                resolvedExposureContentId = exposureContent?.id,
-                resolutionStatus =
-                    if (exposureContent != null) {
-                        PopularNewsletterResolutionStatus.RESOLVED
-                    } else {
-                        PopularNewsletterResolutionStatus.UNRESOLVED
-                    },
-            )
+        val uniqueRawObjectIds = rawObjectIds.distinct()
+        val resolvedByRawObjectId = mutableMapOf<String, PopularNewsletterObjectResolution>()
+        val numericIdByRawObjectId =
+            uniqueRawObjectIds
+                .mapNotNull { rawObjectId ->
+                    rawObjectId.toLongOrNull()?.let { numericId ->
+                        rawObjectId to numericId
+                    }
+                }.toMap()
+
+        resolveByExposureContentId(numericIdByRawObjectId, resolvedByRawObjectId)
+        resolveByContentId(numericIdByRawObjectId, resolvedByRawObjectId)
+        resolveByOriginalUrl(uniqueRawObjectIds, resolvedByRawObjectId)
+        resolveByNewsletterSourceId(uniqueRawObjectIds, resolvedByRawObjectId)
+
+        return uniqueRawObjectIds.associateWith { rawObjectId ->
+            resolvedByRawObjectId[rawObjectId] ?: unresolvedResolution()
+        }
+    }
+
+    private fun resolveByExposureContentId(
+        numericIdByRawObjectId: Map<String, Long>,
+        resolvedByRawObjectId: MutableMap<String, PopularNewsletterObjectResolution>,
+    ) {
+        val numericIds = numericIdByRawObjectId.values.toSet()
+        if (numericIds.isEmpty()) {
+            return
         }
 
-        val newsletterSourceMatches =
+        val exposureContentLookupById =
+            exposureContentRepository
+                .findLookupRowsByIds(numericIds)
+                .associateBy { it.id }
+
+        numericIdByRawObjectId.forEach { (rawObjectId, numericId) ->
+            exposureContentLookupById[numericId]?.let { exposureContent ->
+                resolvedByRawObjectId[rawObjectId] =
+                    PopularNewsletterObjectResolution(
+                        resolvedContentId = exposureContent.contentId,
+                        resolvedExposureContentId = exposureContent.id,
+                        resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
+                    )
+            }
+        }
+    }
+
+    private fun resolveByContentId(
+        numericIdByRawObjectId: Map<String, Long>,
+        resolvedByRawObjectId: MutableMap<String, PopularNewsletterObjectResolution>,
+    ) {
+        val unresolvedNumericIdByRawObjectId =
+            numericIdByRawObjectId.filterKeys { rawObjectId ->
+                !resolvedByRawObjectId.containsKey(rawObjectId)
+            }
+        if (unresolvedNumericIdByRawObjectId.isEmpty()) {
+            return
+        }
+
+        val contentLookupById =
             contentRepository
-                .findByNewsletterSourceId(rawObjectId)
-                .sortedWith(compareByDescending<com.nexters.external.entity.Content> { it.publishedAt }.thenByDescending { it.id ?: 0L })
+                .findLookupRowsByIds(unresolvedNumericIdByRawObjectId.values.toSet())
+                .associateBy { it.id }
+        val exposureLookupByContentId =
+            findExposureLookupByContentId(contentLookupById.keys)
 
-        if (newsletterSourceMatches.isNotEmpty()) {
-            val resolvedMatch =
-                newsletterSourceMatches.firstOrNull { matchedContent ->
-                    matchedContent.id != null && exposureContentRepository.findByContentId(matchedContent.id) != null
-                } ?: newsletterSourceMatches.first()
+        unresolvedNumericIdByRawObjectId.forEach { (rawObjectId, numericId) ->
+            contentLookupById[numericId]?.let { content ->
+                resolvedByRawObjectId[rawObjectId] = toResolution(content.id, exposureLookupByContentId[content.id]?.id)
+            }
+        }
+    }
 
-            val exposureContent = exposureContentRepository.findByContentId(resolvedMatch.id!!)
-            return PopularNewsletterObjectResolution(
-                resolvedContentId = resolvedMatch.id,
-                resolvedExposureContentId = exposureContent?.id,
-                resolutionStatus =
-                    if (exposureContent != null) {
-                        PopularNewsletterResolutionStatus.RESOLVED
-                    } else {
-                        PopularNewsletterResolutionStatus.UNRESOLVED
-                    },
-            )
+    private fun resolveByOriginalUrl(
+        rawObjectIds: List<String>,
+        resolvedByRawObjectId: MutableMap<String, PopularNewsletterObjectResolution>,
+    ) {
+        val unresolvedRawObjectIds = rawObjectIds.filterNot { resolvedByRawObjectId.containsKey(it) }
+        if (unresolvedRawObjectIds.isEmpty()) {
+            return
         }
 
-        return PopularNewsletterObjectResolution(
+        val preferredContentByOriginalUrl =
+            selectPreferredRowsByKey(
+                rows = contentRepository.findLookupRowsByOriginalUrls(unresolvedRawObjectIds.toSet()),
+                keySelector = { it.originalUrl },
+            )
+        val exposureLookupByContentId =
+            findExposureLookupByContentId(preferredContentByOriginalUrl.values.map { it.id }.toSet())
+
+        unresolvedRawObjectIds.forEach { rawObjectId ->
+            preferredContentByOriginalUrl[rawObjectId]?.let { content ->
+                resolvedByRawObjectId[rawObjectId] = toResolution(content.id, exposureLookupByContentId[content.id]?.id)
+            }
+        }
+    }
+
+    private fun resolveByNewsletterSourceId(
+        rawObjectIds: List<String>,
+        resolvedByRawObjectId: MutableMap<String, PopularNewsletterObjectResolution>,
+    ) {
+        val unresolvedRawObjectIds = rawObjectIds.filterNot { resolvedByRawObjectId.containsKey(it) }
+        if (unresolvedRawObjectIds.isEmpty()) {
+            return
+        }
+
+        val sourceMatches = contentRepository.findLookupRowsByNewsletterSourceIds(unresolvedRawObjectIds.toSet())
+        if (sourceMatches.isEmpty()) {
+            return
+        }
+
+        val exposureLookupByContentId =
+            findExposureLookupByContentId(sourceMatches.map { it.id }.toSet())
+        val preferredContentByNewsletterSourceId =
+            selectPreferredRowsByKey(
+                rows = sourceMatches,
+                keySelector = { it.newsletterSourceId ?: return@selectPreferredRowsByKey null },
+                exposureLookupByContentId = exposureLookupByContentId,
+            )
+
+        unresolvedRawObjectIds.forEach { rawObjectId ->
+            preferredContentByNewsletterSourceId[rawObjectId]?.let { content ->
+                resolvedByRawObjectId[rawObjectId] = toResolution(content.id, exposureLookupByContentId[content.id]?.id)
+            }
+        }
+    }
+
+    private fun findExposureLookupByContentId(contentIds: Collection<Long>): Map<Long, ExposureContentLookupRow> {
+        if (contentIds.isEmpty()) {
+            return emptyMap()
+        }
+
+        return exposureContentRepository
+            .findLookupRowsByContentIds(contentIds)
+            .associateBy { it.contentId }
+    }
+
+    private fun selectPreferredRowsByKey(
+        rows: List<ContentLookupRow>,
+        keySelector: (ContentLookupRow) -> String?,
+        exposureLookupByContentId: Map<Long, ExposureContentLookupRow> = emptyMap(),
+    ): Map<String, ContentLookupRow> =
+        rows
+            .groupBy { row -> keySelector(row) }
+            .mapNotNull { (key, candidates) ->
+                key?.let {
+                    val preferredCandidate =
+                        candidates.firstOrNull { candidate -> exposureLookupByContentId.containsKey(candidate.id) }
+                            ?: candidates.firstOrNull()
+                    preferredCandidate?.let { candidate -> key to candidate }
+                }
+            }.toMap()
+
+    private fun toResolution(
+        contentId: Long,
+        exposureContentId: Long?,
+    ): PopularNewsletterObjectResolution =
+        PopularNewsletterObjectResolution(
+            resolvedContentId = contentId,
+            resolvedExposureContentId = exposureContentId,
+            resolutionStatus =
+                if (exposureContentId != null) {
+                    PopularNewsletterResolutionStatus.RESOLVED
+                } else {
+                    PopularNewsletterResolutionStatus.UNRESOLVED
+                },
+        )
+
+    private fun unresolvedResolution(): PopularNewsletterObjectResolution =
+        PopularNewsletterObjectResolution(
             resolutionStatus = PopularNewsletterResolutionStatus.UNRESOLVED,
         )
-    }
 }
 
 data class PopularNewsletterObjectResolution(

--- a/external/src/main/kotlin/com/nexters/external/service/PopularNewsletterSnapshotService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/PopularNewsletterSnapshotService.kt
@@ -1,0 +1,112 @@
+package com.nexters.external.service
+
+import com.nexters.external.entity.ExposureContent
+import com.nexters.external.entity.PopularNewsletterSnapshot
+import com.nexters.external.entity.PopularNewsletterSnapshotItem
+import com.nexters.external.enums.PopularNewsletterResolutionStatus
+import com.nexters.external.enums.PopularNewsletterSegmentType
+import com.nexters.external.enums.PopularNewsletterSnapshotStatus
+import com.nexters.external.repository.ExposureContentRepository
+import com.nexters.external.repository.PopularNewsletterSnapshotItemRepository
+import com.nexters.external.repository.PopularNewsletterSnapshotRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Service
+class PopularNewsletterSnapshotService(
+    private val popularNewsletterSnapshotRepository: PopularNewsletterSnapshotRepository,
+    private val popularNewsletterSnapshotItemRepository: PopularNewsletterSnapshotItemRepository,
+    private val exposureContentRepository: ExposureContentRepository,
+) {
+    @Transactional
+    fun saveSnapshot(command: SavePopularNewsletterSnapshotCommand): PopularNewsletterSnapshot {
+        val snapshot =
+            popularNewsletterSnapshotRepository.save(
+                PopularNewsletterSnapshot(
+                    segmentType = command.segmentType,
+                    segmentKey = command.segmentKey,
+                    windowStartDate = command.windowStartDate,
+                    windowEndDate = command.windowEndDate,
+                    generatedAt = command.generatedAt,
+                    sourceEventName = command.sourceEventName,
+                    candidateLimit = command.candidateLimit,
+                    resolvedItemCount = command.resolvedItemCount,
+                    status = command.status,
+                ),
+            )
+
+        if (command.items.isNotEmpty()) {
+            popularNewsletterSnapshotItemRepository.saveAll(
+                command.items.map { item ->
+                    PopularNewsletterSnapshotItem(
+                        snapshot = snapshot,
+                        rank = item.rank,
+                        rawObjectId = item.rawObjectId,
+                        clickCount = item.clickCount,
+                        resolvedContentId = item.resolvedContentId,
+                        resolvedExposureContentId = item.resolvedExposureContentId,
+                        resolutionStatus = item.resolutionStatus,
+                    )
+                },
+            )
+        }
+
+        return snapshot
+    }
+
+    @Transactional(readOnly = true)
+    fun findLatestFeaturedExposureContent(
+        segmentType: PopularNewsletterSegmentType = PopularNewsletterSegmentType.GLOBAL,
+        segmentKey: String? = null,
+    ): ExposureContent? {
+        val snapshots =
+            popularNewsletterSnapshotRepository.findBySegmentTypeAndSegmentKeyAndStatusOrderByGeneratedAtDesc(
+                segmentType = segmentType,
+                segmentKey = segmentKey,
+                status = PopularNewsletterSnapshotStatus.SUCCESS,
+            )
+
+        for (snapshot in snapshots) {
+            if (snapshot.resolvedItemCount <= 0 || snapshot.id == null) {
+                continue
+            }
+
+            val resolvedItem =
+                popularNewsletterSnapshotItemRepository.findFirstBySnapshotIdAndResolutionStatusOrderByRankAsc(
+                    snapshotId = snapshot.id,
+                    resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
+                ) ?: continue
+
+            val exposureContentId = resolvedItem.resolvedExposureContentId ?: continue
+            exposureContentRepository.findById(exposureContentId).orElse(null)?.let { exposureContent ->
+                return exposureContent
+            }
+        }
+
+        return null
+    }
+}
+
+data class SavePopularNewsletterSnapshotCommand(
+    val segmentType: PopularNewsletterSegmentType,
+    val segmentKey: String? = null,
+    val windowStartDate: LocalDate,
+    val windowEndDate: LocalDate,
+    val generatedAt: LocalDateTime = LocalDateTime.now(),
+    val sourceEventName: String,
+    val candidateLimit: Int,
+    val resolvedItemCount: Int,
+    val status: PopularNewsletterSnapshotStatus,
+    val items: List<SavePopularNewsletterSnapshotItemCommand> = emptyList(),
+)
+
+data class SavePopularNewsletterSnapshotItemCommand(
+    val rank: Int,
+    val rawObjectId: String,
+    val clickCount: Long,
+    val resolvedContentId: Long? = null,
+    val resolvedExposureContentId: Long? = null,
+    val resolutionStatus: PopularNewsletterResolutionStatus,
+)

--- a/external/src/main/kotlin/com/nexters/external/service/PopularNewsletterSnapshotService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/PopularNewsletterSnapshotService.kt
@@ -9,6 +9,7 @@ import com.nexters.external.enums.PopularNewsletterSnapshotStatus
 import com.nexters.external.repository.ExposureContentRepository
 import com.nexters.external.repository.PopularNewsletterSnapshotItemRepository
 import com.nexters.external.repository.PopularNewsletterSnapshotRepository
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -22,6 +23,15 @@ class PopularNewsletterSnapshotService(
 ) {
     @Transactional
     fun saveSnapshot(command: SavePopularNewsletterSnapshotCommand): PopularNewsletterSnapshot {
+        val featuredExposureContentId =
+            command.items
+                .asSequence()
+                .sortedBy { it.rank }
+                .firstOrNull { item ->
+                    item.resolutionStatus == PopularNewsletterResolutionStatus.RESOLVED &&
+                        item.resolvedExposureContentId != null
+                }?.resolvedExposureContentId
+
         val snapshot =
             popularNewsletterSnapshotRepository.save(
                 PopularNewsletterSnapshot(
@@ -33,6 +43,7 @@ class PopularNewsletterSnapshotService(
                     sourceEventName = command.sourceEventName,
                     candidateLimit = command.candidateLimit,
                     resolvedItemCount = command.resolvedItemCount,
+                    featuredExposureContentId = featuredExposureContentId,
                     status = command.status,
                 ),
             )
@@ -61,31 +72,18 @@ class PopularNewsletterSnapshotService(
         segmentType: PopularNewsletterSegmentType = PopularNewsletterSegmentType.GLOBAL,
         segmentKey: String? = null,
     ): ExposureContent? {
-        val snapshots =
-            popularNewsletterSnapshotRepository.findBySegmentTypeAndSegmentKeyAndStatusOrderByGeneratedAtDesc(
-                segmentType = segmentType,
-                segmentKey = segmentKey,
-                status = PopularNewsletterSnapshotStatus.SUCCESS,
-            )
+        val latestSnapshot =
+            popularNewsletterSnapshotRepository
+                .findLatestFeaturedBySegmentTypeAndSegmentKeyAndStatus(
+                    segmentType = segmentType,
+                    segmentKey = segmentKey,
+                    status = PopularNewsletterSnapshotStatus.SUCCESS,
+                    pageable = PageRequest.of(0, 1),
+                ).firstOrNull()
+                ?: return null
 
-        for (snapshot in snapshots) {
-            if (snapshot.resolvedItemCount <= 0 || snapshot.id == null) {
-                continue
-            }
-
-            val resolvedItem =
-                popularNewsletterSnapshotItemRepository.findFirstBySnapshotIdAndResolutionStatusOrderByRankAsc(
-                    snapshotId = snapshot.id,
-                    resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
-                ) ?: continue
-
-            val exposureContentId = resolvedItem.resolvedExposureContentId ?: continue
-            exposureContentRepository.findById(exposureContentId).orElse(null)?.let { exposureContent ->
-                return exposureContent
-            }
-        }
-
-        return null
+        return latestSnapshot.featuredExposureContentId
+            ?.let { exposureContentId -> exposureContentRepository.findById(exposureContentId).orElse(null) }
     }
 }
 

--- a/external/src/main/resources/schema.sql
+++ b/external/src/main/resources/schema.sql
@@ -52,16 +52,38 @@ CREATE TABLE IF NOT EXISTS contents
 (
     id                   SERIAL PRIMARY KEY,
     newsletter_source_id VARCHAR(255),
-    title                VARCHAR(255) NOT NULL,
+    title                TEXT         NOT NULL,
     content              TEXT         NOT NULL,
-    newsletter_name      VARCHAR(255) NOT NULL,
-    original_url         VARCHAR(255) NOT NULL,
-    image_url            VARCHAR(1024),
+    newsletter_name      TEXT         NOT NULL,
+    original_url         TEXT         NOT NULL,
+    image_url            TEXT,
     published_at         DATE         NOT NULL,
     created_at           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     content_provider_id  BIGINT
 );
+
+-- Backfill columns for older PostgreSQL databases
+ALTER TABLE contents
+    ADD COLUMN IF NOT EXISTS newsletter_source_id VARCHAR(255);
+
+ALTER TABLE contents
+    ADD COLUMN IF NOT EXISTS image_url VARCHAR(1024);
+
+ALTER TABLE contents
+    ADD COLUMN IF NOT EXISTS content_provider_id BIGINT;
+
+ALTER TABLE contents
+    ALTER COLUMN title TYPE TEXT;
+
+ALTER TABLE contents
+    ALTER COLUMN newsletter_name TYPE TEXT;
+
+ALTER TABLE contents
+    ALTER COLUMN original_url TYPE TEXT;
+
+ALTER TABLE contents
+    ALTER COLUMN image_url TYPE TEXT;
 
 CREATE TABLE IF NOT EXISTS content_generation_attempts
 (
@@ -218,6 +240,39 @@ CREATE TABLE IF NOT EXISTS content_provider
     created_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+-- RSS processing status table
+CREATE TABLE IF NOT EXISTS rss_processing_status
+(
+    id                   BIGSERIAL PRIMARY KEY,
+    newsletter_source_id VARCHAR(255)  NOT NULL UNIQUE,
+    rss_url              TEXT          NOT NULL,
+    item_url             TEXT          NOT NULL UNIQUE,
+    title                TEXT          NOT NULL,
+    is_processed         BOOLEAN       NOT NULL DEFAULT FALSE,
+    ai_processed         BOOLEAN       NOT NULL DEFAULT FALSE,
+    content_id           BIGINT,
+    processing_error     TEXT,
+    priority             INTEGER       NOT NULL DEFAULT 0,
+    created_at           TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    processed_at         TIMESTAMP,
+    ai_processed_at      TIMESTAMP
+);
+
+ALTER TABLE rss_processing_status
+    ALTER COLUMN rss_url TYPE TEXT;
+
+ALTER TABLE rss_processing_status
+    ALTER COLUMN item_url TYPE TEXT;
+
+ALTER TABLE rss_processing_status
+    ALTER COLUMN title TYPE TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_rss_processing_status_rss_url
+    ON rss_processing_status (rss_url);
+
+CREATE INDEX IF NOT EXISTS idx_rss_processing_status_ai_processed_created_at
+    ON rss_processing_status (ai_processed, is_processed, created_at DESC);
 
 -- Content provider category mappings table
 CREATE TABLE IF NOT EXISTS content_provider_category_mappings

--- a/external/src/main/resources/schema.sql
+++ b/external/src/main/resources/schema.sql
@@ -379,25 +379,6 @@ CREATE INDEX IF NOT EXISTS idx_popular_newsletter_snapshot_items_snapshot_id
 CREATE INDEX IF NOT EXISTS idx_popular_newsletter_snapshot_items_snapshot_resolution_rank
     ON popular_newsletter_snapshot_items (snapshot_id, resolution_status, rank_order);
 
-UPDATE popular_newsletter_snapshots snapshots
-SET featured_exposure_content_id = (
-    SELECT items.resolved_exposure_content_id
-    FROM popular_newsletter_snapshot_items items
-    WHERE items.snapshot_id = snapshots.id
-      AND items.resolution_status = 'RESOLVED'
-      AND items.resolved_exposure_content_id IS NOT NULL
-    ORDER BY items.rank_order ASC
-    LIMIT 1
-)
-WHERE snapshots.featured_exposure_content_id IS NULL
-  AND EXISTS (
-    SELECT 1
-    FROM popular_newsletter_snapshot_items items
-    WHERE items.snapshot_id = snapshots.id
-      AND items.resolution_status = 'RESOLVED'
-      AND items.resolved_exposure_content_id IS NOT NULL
-);
-
 COMMENT ON TABLE popular_newsletter_snapshots IS '인기 뉴스레터 랭킹 스냅샷 메타데이터';
 
 COMMENT ON TABLE popular_newsletter_snapshot_items IS '인기 뉴스레터 스냅샷 개별 랭킹 아이템';

--- a/external/src/main/resources/schema.sql
+++ b/external/src/main/resources/schema.sql
@@ -257,3 +257,54 @@ CREATE TABLE IF NOT EXISTS content_provider_requests
     created_at            TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at            TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS popular_newsletter_snapshots
+(
+    id                 BIGSERIAL PRIMARY KEY,
+    segment_type       VARCHAR(20) NOT NULL CHECK (segment_type IN ('GLOBAL', 'CATEGORY', 'JOB_GROUP')),
+    segment_key        VARCHAR(255),
+    window_start_date  DATE        NOT NULL,
+    window_end_date    DATE        NOT NULL,
+    generated_at       TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    source_event_name  VARCHAR(255) NOT NULL,
+    candidate_limit    INTEGER     NOT NULL,
+    resolved_item_count INTEGER    NOT NULL DEFAULT 0,
+    status             VARCHAR(20) NOT NULL CHECK (status IN ('SUCCESS', 'FAILED'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_popular_newsletter_snapshot_segment_generated_at
+    ON popular_newsletter_snapshots (segment_type, segment_key, generated_at DESC);
+
+CREATE TABLE IF NOT EXISTS popular_newsletter_snapshot_items
+(
+    id                          BIGSERIAL PRIMARY KEY,
+    snapshot_id                 BIGINT      NOT NULL,
+    rank_order                  INTEGER     NOT NULL,
+    raw_object_id               VARCHAR(1024) NOT NULL,
+    click_count                 BIGINT      NOT NULL,
+    resolved_content_id         BIGINT,
+    resolved_exposure_content_id BIGINT,
+    resolution_status           VARCHAR(20) NOT NULL CHECK (resolution_status IN ('RESOLVED', 'UNRESOLVED')),
+    created_at                  TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                  TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_popular_newsletter_snapshot_items_snapshot
+        FOREIGN KEY (snapshot_id) REFERENCES popular_newsletter_snapshots (id),
+    CONSTRAINT fk_popular_newsletter_snapshot_items_content
+        FOREIGN KEY (resolved_content_id) REFERENCES contents (id),
+    CONSTRAINT fk_popular_newsletter_snapshot_items_exposure_content
+        FOREIGN KEY (resolved_exposure_content_id) REFERENCES exposure_contents (id),
+    CONSTRAINT uk_popular_newsletter_snapshot_item_snapshot_rank UNIQUE (snapshot_id, rank_order)
+);
+
+ALTER TABLE popular_newsletter_snapshot_items
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE popular_newsletter_snapshot_items
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_popular_newsletter_snapshot_items_snapshot_id
+    ON popular_newsletter_snapshot_items (snapshot_id);
+
+COMMENT ON TABLE popular_newsletter_snapshots IS '인기 뉴스레터 랭킹 스냅샷 메타데이터';
+
+COMMENT ON TABLE popular_newsletter_snapshot_items IS '인기 뉴스레터 스냅샷 개별 랭킹 아이템';

--- a/external/src/main/resources/schema.sql
+++ b/external/src/main/resources/schema.sql
@@ -315,20 +315,36 @@ CREATE TABLE IF NOT EXISTS content_provider_requests
 
 CREATE TABLE IF NOT EXISTS popular_newsletter_snapshots
 (
-    id                 BIGSERIAL PRIMARY KEY,
-    segment_type       VARCHAR(20) NOT NULL CHECK (segment_type IN ('GLOBAL', 'CATEGORY', 'JOB_GROUP')),
-    segment_key        VARCHAR(255),
-    window_start_date  DATE        NOT NULL,
-    window_end_date    DATE        NOT NULL,
-    generated_at       TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    source_event_name  VARCHAR(255) NOT NULL,
-    candidate_limit    INTEGER     NOT NULL,
-    resolved_item_count INTEGER    NOT NULL DEFAULT 0,
-    status             VARCHAR(20) NOT NULL CHECK (status IN ('SUCCESS', 'FAILED'))
+    id                          BIGSERIAL PRIMARY KEY,
+    segment_type                VARCHAR(20)  NOT NULL CHECK (segment_type IN ('GLOBAL', 'CATEGORY', 'JOB_GROUP')),
+    segment_key                 VARCHAR(255),
+    window_start_date           DATE         NOT NULL,
+    window_end_date             DATE         NOT NULL,
+    generated_at                TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    source_event_name           VARCHAR(255) NOT NULL,
+    candidate_limit             INTEGER      NOT NULL,
+    resolved_item_count         INTEGER      NOT NULL DEFAULT 0,
+    featured_exposure_content_id BIGINT,
+    status                      VARCHAR(20)  NOT NULL CHECK (status IN ('SUCCESS', 'FAILED')),
+    CONSTRAINT fk_popular_newsletter_snapshots_featured_exposure_content
+        FOREIGN KEY (featured_exposure_content_id) REFERENCES exposure_contents (id)
 );
+
+ALTER TABLE popular_newsletter_snapshots
+    ADD COLUMN IF NOT EXISTS featured_exposure_content_id BIGINT;
+
+ALTER TABLE popular_newsletter_snapshots
+    DROP CONSTRAINT IF EXISTS fk_popular_newsletter_snapshots_featured_exposure_content;
+
+ALTER TABLE popular_newsletter_snapshots
+    ADD CONSTRAINT fk_popular_newsletter_snapshots_featured_exposure_content
+        FOREIGN KEY (featured_exposure_content_id) REFERENCES exposure_contents (id);
 
 CREATE INDEX IF NOT EXISTS idx_popular_newsletter_snapshot_segment_generated_at
     ON popular_newsletter_snapshots (segment_type, segment_key, generated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_popular_newsletter_snapshot_segment_status_generated_at
+    ON popular_newsletter_snapshots (segment_type, status, segment_key, generated_at DESC);
 
 CREATE TABLE IF NOT EXISTS popular_newsletter_snapshot_items
 (
@@ -360,6 +376,34 @@ ALTER TABLE popular_newsletter_snapshot_items
 CREATE INDEX IF NOT EXISTS idx_popular_newsletter_snapshot_items_snapshot_id
     ON popular_newsletter_snapshot_items (snapshot_id);
 
+CREATE INDEX IF NOT EXISTS idx_popular_newsletter_snapshot_items_snapshot_resolution_rank
+    ON popular_newsletter_snapshot_items (snapshot_id, resolution_status, rank_order);
+
+UPDATE popular_newsletter_snapshots snapshots
+SET featured_exposure_content_id = (
+    SELECT items.resolved_exposure_content_id
+    FROM popular_newsletter_snapshot_items items
+    WHERE items.snapshot_id = snapshots.id
+      AND items.resolution_status = 'RESOLVED'
+      AND items.resolved_exposure_content_id IS NOT NULL
+    ORDER BY items.rank_order ASC
+    LIMIT 1
+)
+WHERE snapshots.featured_exposure_content_id IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM popular_newsletter_snapshot_items items
+    WHERE items.snapshot_id = snapshots.id
+      AND items.resolution_status = 'RESOLVED'
+      AND items.resolved_exposure_content_id IS NOT NULL
+);
+
 COMMENT ON TABLE popular_newsletter_snapshots IS '인기 뉴스레터 랭킹 스냅샷 메타데이터';
 
 COMMENT ON TABLE popular_newsletter_snapshot_items IS '인기 뉴스레터 스냅샷 개별 랭킹 아이템';
+
+CREATE INDEX IF NOT EXISTS idx_contents_original_url
+    ON contents (original_url);
+
+CREATE INDEX IF NOT EXISTS idx_contents_newsletter_source_published_id
+    ON contents (newsletter_source_id, published_at DESC, id DESC);

--- a/external/src/test/kotlin/com/nexters/external/service/PopularNewsletterObjectIdResolverServiceTest.kt
+++ b/external/src/test/kotlin/com/nexters/external/service/PopularNewsletterObjectIdResolverServiceTest.kt
@@ -1,14 +1,13 @@
 package com.nexters.external.service
 
-import com.nexters.external.entity.Content
-import com.nexters.external.entity.ExposureContent
 import com.nexters.external.enums.PopularNewsletterResolutionStatus
+import com.nexters.external.repository.ContentLookupRow
 import com.nexters.external.repository.ContentRepository
+import com.nexters.external.repository.ExposureContentLookupRow
 import com.nexters.external.repository.ExposureContentRepository
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import java.time.LocalDate
-import java.util.Optional
 import kotlin.test.assertEquals
 
 class PopularNewsletterObjectIdResolverServiceTest {
@@ -22,142 +21,132 @@ class PopularNewsletterObjectIdResolverServiceTest {
         )
 
     @Test
-    fun `resolveObjectId should prioritize exposure content id`() {
-        val exposureContent = createExposureContent(exposureContentId = 11L, contentId = 101L)
-
+    fun `resolveObjectIds should resolve mixed inputs with bulk lookups`() {
         Mockito
-            .`when`(exposureContentRepository.findById(11L))
-            .thenReturn(Optional.of(exposureContent))
+            .`when`(exposureContentRepository.findLookupRowsByIds(setOf(11L, 101L)))
+            .thenReturn(listOf(ExposureContentLookupRow(id = 11L, contentId = 201L)))
+        Mockito
+            .`when`(contentRepository.findLookupRowsByIds(setOf(101L)))
+            .thenReturn(
+                listOf(
+                    ContentLookupRow(
+                        id = 101L,
+                        originalUrl = "https://example.com/articles/101",
+                        newsletterSourceId = "source-101",
+                        publishedAt = LocalDate.of(2026, 4, 18),
+                    ),
+                ),
+            )
+        Mockito
+            .`when`(
+                contentRepository.findLookupRowsByOriginalUrls(
+                    setOf("https://example.com/articles/1", "source-1", "unknown-object"),
+                ),
+            ).thenReturn(
+                listOf(
+                    ContentLookupRow(
+                        id = 301L,
+                        originalUrl = "https://example.com/articles/1",
+                        newsletterSourceId = "source-301",
+                        publishedAt = LocalDate.of(2026, 4, 18),
+                    ),
+                ),
+            )
+        Mockito
+            .`when`(contentRepository.findLookupRowsByNewsletterSourceIds(setOf("source-1", "unknown-object")))
+            .thenReturn(
+                listOf(
+                    ContentLookupRow(
+                        id = 402L,
+                        originalUrl = "https://example.com/articles/402",
+                        newsletterSourceId = "source-1",
+                        publishedAt = LocalDate.of(2026, 4, 12),
+                    ),
+                    ContentLookupRow(
+                        id = 401L,
+                        originalUrl = "https://example.com/articles/401",
+                        newsletterSourceId = "source-1",
+                        publishedAt = LocalDate.of(2026, 4, 10),
+                    ),
+                ),
+            )
+        Mockito
+            .`when`(exposureContentRepository.findLookupRowsByContentIds(setOf(101L)))
+            .thenReturn(listOf(ExposureContentLookupRow(id = 111L, contentId = 101L)))
+        Mockito
+            .`when`(exposureContentRepository.findLookupRowsByContentIds(setOf(301L)))
+            .thenReturn(listOf(ExposureContentLookupRow(id = 311L, contentId = 301L)))
+        Mockito
+            .`when`(exposureContentRepository.findLookupRowsByContentIds(setOf(402L, 401L)))
+            .thenReturn(listOf(ExposureContentLookupRow(id = 411L, contentId = 401L)))
+
+        val result =
+            sut.resolveObjectIds(
+                listOf(
+                    "11",
+                    "101",
+                    "https://example.com/articles/1",
+                    "source-1",
+                    "unknown-object",
+                ),
+            )
+
+        assertEquals(
+            PopularNewsletterObjectResolution(
+                resolvedContentId = 201L,
+                resolvedExposureContentId = 11L,
+                resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
+            ),
+            result["11"],
+        )
+        assertEquals(
+            PopularNewsletterObjectResolution(
+                resolvedContentId = 101L,
+                resolvedExposureContentId = 111L,
+                resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
+            ),
+            result["101"],
+        )
+        assertEquals(
+            PopularNewsletterObjectResolution(
+                resolvedContentId = 301L,
+                resolvedExposureContentId = 311L,
+                resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
+            ),
+            result["https://example.com/articles/1"],
+        )
+        assertEquals(
+            PopularNewsletterObjectResolution(
+                resolvedContentId = 401L,
+                resolvedExposureContentId = 411L,
+                resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
+            ),
+            result["source-1"],
+        )
+        assertEquals(
+            PopularNewsletterObjectResolution(
+                resolutionStatus = PopularNewsletterResolutionStatus.UNRESOLVED,
+            ),
+            result["unknown-object"],
+        )
+
+        Mockito.verify(exposureContentRepository, Mockito.never()).findById(Mockito.anyLong())
+        Mockito.verify(contentRepository, Mockito.never()).findById(Mockito.anyLong())
+        Mockito.verify(contentRepository, Mockito.never()).findByOriginalUrl(Mockito.anyString())
+        Mockito.verify(contentRepository, Mockito.never()).findByNewsletterSourceId(Mockito.anyString())
+        Mockito.verify(exposureContentRepository, Mockito.never()).findByContentId(Mockito.anyLong())
+    }
+
+    @Test
+    fun `resolveObjectId should delegate to bulk resolver`() {
+        Mockito
+            .`when`(exposureContentRepository.findLookupRowsByIds(setOf(11L)))
+            .thenReturn(listOf(ExposureContentLookupRow(id = 11L, contentId = 101L)))
 
         val result = sut.resolveObjectId("11")
 
         assertEquals(101L, result.resolvedContentId)
         assertEquals(11L, result.resolvedExposureContentId)
         assertEquals(PopularNewsletterResolutionStatus.RESOLVED, result.resolutionStatus)
-        Mockito.verify(contentRepository, Mockito.never()).findById(11L)
     }
-
-    @Test
-    fun `resolveObjectId should resolve by content id when exposure content id lookup misses`() {
-        val content = createContent(contentId = 101L)
-        val exposureContent = createExposureContent(exposureContentId = 11L, content = content)
-
-        Mockito
-            .`when`(exposureContentRepository.findById(101L))
-            .thenReturn(Optional.empty())
-        Mockito
-            .`when`(contentRepository.findById(101L))
-            .thenReturn(Optional.of(content))
-        Mockito
-            .`when`(exposureContentRepository.findByContentId(101L))
-            .thenReturn(exposureContent)
-
-        val result = sut.resolveObjectId("101")
-
-        assertEquals(101L, result.resolvedContentId)
-        assertEquals(11L, result.resolvedExposureContentId)
-        assertEquals(PopularNewsletterResolutionStatus.RESOLVED, result.resolutionStatus)
-    }
-
-    @Test
-    fun `resolveObjectId should resolve by original url`() {
-        val content = createContent(contentId = 101L, originalUrl = "https://example.com/articles/1")
-        val exposureContent = createExposureContent(exposureContentId = 11L, content = content)
-
-        Mockito
-            .`when`(contentRepository.findByOriginalUrl("https://example.com/articles/1"))
-            .thenReturn(content)
-        Mockito
-            .`when`(exposureContentRepository.findByContentId(101L))
-            .thenReturn(exposureContent)
-
-        val result = sut.resolveObjectId("https://example.com/articles/1")
-
-        assertEquals(101L, result.resolvedContentId)
-        assertEquals(11L, result.resolvedExposureContentId)
-        assertEquals(PopularNewsletterResolutionStatus.RESOLVED, result.resolutionStatus)
-    }
-
-    @Test
-    fun `resolveObjectId should prefer newsletter source content that has exposure`() {
-        val olderResolvedContent =
-            createContent(
-                contentId = 101L,
-                newsletterSourceId = "source-1",
-                publishedAt = LocalDate.of(2026, 4, 10),
-            )
-        val latestUnresolvedContent =
-            createContent(
-                contentId = 102L,
-                newsletterSourceId = "source-1",
-                publishedAt = LocalDate.of(2026, 4, 12),
-            )
-        val exposureContent = createExposureContent(exposureContentId = 11L, content = olderResolvedContent)
-
-        Mockito
-            .`when`(contentRepository.findByOriginalUrl("source-1"))
-            .thenReturn(null)
-        Mockito
-            .`when`(contentRepository.findByNewsletterSourceId("source-1"))
-            .thenReturn(listOf(latestUnresolvedContent, olderResolvedContent))
-        Mockito
-            .`when`(exposureContentRepository.findByContentId(102L))
-            .thenReturn(null)
-        Mockito
-            .`when`(exposureContentRepository.findByContentId(101L))
-            .thenReturn(exposureContent)
-
-        val result = sut.resolveObjectId("source-1")
-
-        assertEquals(101L, result.resolvedContentId)
-        assertEquals(11L, result.resolvedExposureContentId)
-        assertEquals(PopularNewsletterResolutionStatus.RESOLVED, result.resolutionStatus)
-    }
-
-    @Test
-    fun `resolveObjectId should return unresolved when no mapping exists`() {
-        Mockito
-            .`when`(contentRepository.findByOriginalUrl("unknown-object"))
-            .thenReturn(null)
-        Mockito
-            .`when`(contentRepository.findByNewsletterSourceId("unknown-object"))
-            .thenReturn(emptyList())
-
-        val result = sut.resolveObjectId("unknown-object")
-
-        assertEquals(null, result.resolvedContentId)
-        assertEquals(null, result.resolvedExposureContentId)
-        assertEquals(PopularNewsletterResolutionStatus.UNRESOLVED, result.resolutionStatus)
-    }
-
-    private fun createContent(
-        contentId: Long,
-        newsletterSourceId: String? = "newsletter-source-id",
-        originalUrl: String = "https://example.com/articles/$contentId",
-        publishedAt: LocalDate = LocalDate.of(2026, 4, 18),
-    ): Content =
-        Content(
-            id = contentId,
-            newsletterSourceId = newsletterSourceId,
-            title = "title-$contentId",
-            content = "content-$contentId",
-            newsletterName = "newsletter-$contentId",
-            originalUrl = originalUrl,
-            imageUrl = null,
-            publishedAt = publishedAt,
-            contentProvider = null,
-        )
-
-    private fun createExposureContent(
-        exposureContentId: Long,
-        contentId: Long = 101L,
-        content: Content = createContent(contentId = contentId),
-    ): ExposureContent =
-        ExposureContent(
-            id = exposureContentId,
-            content = content,
-            provocativeKeyword = "keyword",
-            provocativeHeadline = "headline",
-            summaryContent = "summary",
-        )
 }

--- a/external/src/test/kotlin/com/nexters/external/service/PopularNewsletterObjectIdResolverServiceTest.kt
+++ b/external/src/test/kotlin/com/nexters/external/service/PopularNewsletterObjectIdResolverServiceTest.kt
@@ -1,0 +1,163 @@
+package com.nexters.external.service
+
+import com.nexters.external.entity.Content
+import com.nexters.external.entity.ExposureContent
+import com.nexters.external.enums.PopularNewsletterResolutionStatus
+import com.nexters.external.repository.ContentRepository
+import com.nexters.external.repository.ExposureContentRepository
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import java.time.LocalDate
+import java.util.Optional
+import kotlin.test.assertEquals
+
+class PopularNewsletterObjectIdResolverServiceTest {
+    private val contentRepository: ContentRepository = Mockito.mock(ContentRepository::class.java)
+    private val exposureContentRepository: ExposureContentRepository = Mockito.mock(ExposureContentRepository::class.java)
+
+    private val sut =
+        PopularNewsletterObjectIdResolverService(
+            contentRepository = contentRepository,
+            exposureContentRepository = exposureContentRepository,
+        )
+
+    @Test
+    fun `resolveObjectId should prioritize exposure content id`() {
+        val exposureContent = createExposureContent(exposureContentId = 11L, contentId = 101L)
+
+        Mockito
+            .`when`(exposureContentRepository.findById(11L))
+            .thenReturn(Optional.of(exposureContent))
+
+        val result = sut.resolveObjectId("11")
+
+        assertEquals(101L, result.resolvedContentId)
+        assertEquals(11L, result.resolvedExposureContentId)
+        assertEquals(PopularNewsletterResolutionStatus.RESOLVED, result.resolutionStatus)
+        Mockito.verify(contentRepository, Mockito.never()).findById(11L)
+    }
+
+    @Test
+    fun `resolveObjectId should resolve by content id when exposure content id lookup misses`() {
+        val content = createContent(contentId = 101L)
+        val exposureContent = createExposureContent(exposureContentId = 11L, content = content)
+
+        Mockito
+            .`when`(exposureContentRepository.findById(101L))
+            .thenReturn(Optional.empty())
+        Mockito
+            .`when`(contentRepository.findById(101L))
+            .thenReturn(Optional.of(content))
+        Mockito
+            .`when`(exposureContentRepository.findByContentId(101L))
+            .thenReturn(exposureContent)
+
+        val result = sut.resolveObjectId("101")
+
+        assertEquals(101L, result.resolvedContentId)
+        assertEquals(11L, result.resolvedExposureContentId)
+        assertEquals(PopularNewsletterResolutionStatus.RESOLVED, result.resolutionStatus)
+    }
+
+    @Test
+    fun `resolveObjectId should resolve by original url`() {
+        val content = createContent(contentId = 101L, originalUrl = "https://example.com/articles/1")
+        val exposureContent = createExposureContent(exposureContentId = 11L, content = content)
+
+        Mockito
+            .`when`(contentRepository.findByOriginalUrl("https://example.com/articles/1"))
+            .thenReturn(content)
+        Mockito
+            .`when`(exposureContentRepository.findByContentId(101L))
+            .thenReturn(exposureContent)
+
+        val result = sut.resolveObjectId("https://example.com/articles/1")
+
+        assertEquals(101L, result.resolvedContentId)
+        assertEquals(11L, result.resolvedExposureContentId)
+        assertEquals(PopularNewsletterResolutionStatus.RESOLVED, result.resolutionStatus)
+    }
+
+    @Test
+    fun `resolveObjectId should prefer newsletter source content that has exposure`() {
+        val olderResolvedContent =
+            createContent(
+                contentId = 101L,
+                newsletterSourceId = "source-1",
+                publishedAt = LocalDate.of(2026, 4, 10),
+            )
+        val latestUnresolvedContent =
+            createContent(
+                contentId = 102L,
+                newsletterSourceId = "source-1",
+                publishedAt = LocalDate.of(2026, 4, 12),
+            )
+        val exposureContent = createExposureContent(exposureContentId = 11L, content = olderResolvedContent)
+
+        Mockito
+            .`when`(contentRepository.findByOriginalUrl("source-1"))
+            .thenReturn(null)
+        Mockito
+            .`when`(contentRepository.findByNewsletterSourceId("source-1"))
+            .thenReturn(listOf(latestUnresolvedContent, olderResolvedContent))
+        Mockito
+            .`when`(exposureContentRepository.findByContentId(102L))
+            .thenReturn(null)
+        Mockito
+            .`when`(exposureContentRepository.findByContentId(101L))
+            .thenReturn(exposureContent)
+
+        val result = sut.resolveObjectId("source-1")
+
+        assertEquals(101L, result.resolvedContentId)
+        assertEquals(11L, result.resolvedExposureContentId)
+        assertEquals(PopularNewsletterResolutionStatus.RESOLVED, result.resolutionStatus)
+    }
+
+    @Test
+    fun `resolveObjectId should return unresolved when no mapping exists`() {
+        Mockito
+            .`when`(contentRepository.findByOriginalUrl("unknown-object"))
+            .thenReturn(null)
+        Mockito
+            .`when`(contentRepository.findByNewsletterSourceId("unknown-object"))
+            .thenReturn(emptyList())
+
+        val result = sut.resolveObjectId("unknown-object")
+
+        assertEquals(null, result.resolvedContentId)
+        assertEquals(null, result.resolvedExposureContentId)
+        assertEquals(PopularNewsletterResolutionStatus.UNRESOLVED, result.resolutionStatus)
+    }
+
+    private fun createContent(
+        contentId: Long,
+        newsletterSourceId: String? = "newsletter-source-id",
+        originalUrl: String = "https://example.com/articles/$contentId",
+        publishedAt: LocalDate = LocalDate.of(2026, 4, 18),
+    ): Content =
+        Content(
+            id = contentId,
+            newsletterSourceId = newsletterSourceId,
+            title = "title-$contentId",
+            content = "content-$contentId",
+            newsletterName = "newsletter-$contentId",
+            originalUrl = originalUrl,
+            imageUrl = null,
+            publishedAt = publishedAt,
+            contentProvider = null,
+        )
+
+    private fun createExposureContent(
+        exposureContentId: Long,
+        contentId: Long = 101L,
+        content: Content = createContent(contentId = contentId),
+    ): ExposureContent =
+        ExposureContent(
+            id = exposureContentId,
+            content = content,
+            provocativeKeyword = "keyword",
+            provocativeHeadline = "headline",
+            summaryContent = "summary",
+        )
+}

--- a/external/src/test/kotlin/com/nexters/external/service/PopularNewsletterSnapshotServiceTest.kt
+++ b/external/src/test/kotlin/com/nexters/external/service/PopularNewsletterSnapshotServiceTest.kt
@@ -3,7 +3,6 @@ package com.nexters.external.service
 import com.nexters.external.entity.Content
 import com.nexters.external.entity.ExposureContent
 import com.nexters.external.entity.PopularNewsletterSnapshot
-import com.nexters.external.entity.PopularNewsletterSnapshotItem
 import com.nexters.external.enums.PopularNewsletterResolutionStatus
 import com.nexters.external.enums.PopularNewsletterSegmentType
 import com.nexters.external.enums.PopularNewsletterSnapshotStatus
@@ -12,9 +11,12 @@ import com.nexters.external.repository.PopularNewsletterSnapshotItemRepository
 import com.nexters.external.repository.PopularNewsletterSnapshotRepository
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
+import org.springframework.data.domain.PageRequest
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.Optional
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 
@@ -34,18 +36,13 @@ class PopularNewsletterSnapshotServiceTest {
         )
 
     @Test
-    fun `findLatestFeaturedExposureContent should fall back to older resolved snapshot`() {
-        val latestSnapshot =
+    fun `findLatestFeaturedExposureContent should return exposure content from latest featured snapshot`() {
+        val latestFeaturedSnapshot =
             createSnapshot(
                 id = 2L,
                 generatedAt = LocalDateTime.of(2026, 4, 18, 7, 30),
                 resolvedItemCount = 0,
-            )
-        val olderSnapshot =
-            createSnapshot(
-                id = 1L,
-                generatedAt = LocalDateTime.of(2026, 4, 17, 7, 30),
-                resolvedItemCount = 1,
+                featuredExposureContentId = 11L,
             )
         val featuredExposureContent =
             ExposureContent(
@@ -65,33 +62,16 @@ class PopularNewsletterSnapshotServiceTest {
                 provocativeHeadline = "headline",
                 summaryContent = "summary",
             )
-        val olderResolvedItem =
-            PopularNewsletterSnapshotItem(
-                id = 21L,
-                snapshot = olderSnapshot,
-                rank = 1,
-                rawObjectId = "11",
-                clickCount = 120L,
-                resolvedContentId = 101L,
-                resolvedExposureContentId = 11L,
-                resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
-            )
 
         Mockito
             .`when`(
-                popularNewsletterSnapshotRepository.findBySegmentTypeAndSegmentKeyAndStatusOrderByGeneratedAtDesc(
+                popularNewsletterSnapshotRepository.findLatestFeaturedBySegmentTypeAndSegmentKeyAndStatus(
                     PopularNewsletterSegmentType.GLOBAL,
                     null,
                     PopularNewsletterSnapshotStatus.SUCCESS,
+                    PageRequest.of(0, 1),
                 ),
-            ).thenReturn(listOf(latestSnapshot, olderSnapshot))
-        Mockito
-            .`when`(
-                popularNewsletterSnapshotItemRepository.findFirstBySnapshotIdAndResolutionStatusOrderByRankAsc(
-                    1L,
-                    PopularNewsletterResolutionStatus.RESOLVED,
-                ),
-            ).thenReturn(olderResolvedItem)
+            ).thenReturn(listOf(latestFeaturedSnapshot))
         Mockito
             .`when`(exposureContentRepository.findById(11L))
             .thenReturn(Optional.of(featuredExposureContent))
@@ -99,22 +79,17 @@ class PopularNewsletterSnapshotServiceTest {
         val result = sut.findLatestFeaturedExposureContent()
 
         assertSame(featuredExposureContent, result)
-        Mockito
-            .verify(popularNewsletterSnapshotItemRepository, Mockito.never())
-            .findFirstBySnapshotIdAndResolutionStatusOrderByRankAsc(
-                2L,
-                PopularNewsletterResolutionStatus.RESOLVED,
-            )
     }
 
     @Test
     fun `findLatestFeaturedExposureContent should return null when there is no resolved snapshot`() {
         Mockito
             .`when`(
-                popularNewsletterSnapshotRepository.findBySegmentTypeAndSegmentKeyAndStatusOrderByGeneratedAtDesc(
+                popularNewsletterSnapshotRepository.findLatestFeaturedBySegmentTypeAndSegmentKeyAndStatus(
                     PopularNewsletterSegmentType.GLOBAL,
                     null,
                     PopularNewsletterSnapshotStatus.SUCCESS,
+                    PageRequest.of(0, 1),
                 ),
             ).thenReturn(emptyList())
 
@@ -123,10 +98,61 @@ class PopularNewsletterSnapshotServiceTest {
         assertNull(result)
     }
 
+    @Test
+    fun `saveSnapshot should persist featured exposure content id from first resolved item`() {
+        var savedSnapshot: PopularNewsletterSnapshot? = null
+
+        Mockito
+            .doAnswer { invocation ->
+                invocation.getArgument<PopularNewsletterSnapshot>(0).also { snapshot ->
+                    savedSnapshot = snapshot
+                }
+            }.`when`(popularNewsletterSnapshotRepository)
+            .save(Mockito.any(PopularNewsletterSnapshot::class.java))
+        Mockito
+            .doAnswer { invocation -> invocation.getArgument(0) }
+            .`when`(popularNewsletterSnapshotItemRepository)
+            .saveAll(Mockito.anyList())
+
+        val result =
+            sut.saveSnapshot(
+                SavePopularNewsletterSnapshotCommand(
+                    segmentType = PopularNewsletterSegmentType.GLOBAL,
+                    windowStartDate = LocalDate.of(2025, 4, 19),
+                    windowEndDate = LocalDate.of(2026, 4, 18),
+                    sourceEventName = "click_newsletter",
+                    candidateLimit = 20,
+                    resolvedItemCount = 1,
+                    status = PopularNewsletterSnapshotStatus.SUCCESS,
+                    items =
+                        listOf(
+                            SavePopularNewsletterSnapshotItemCommand(
+                                rank = 2,
+                                rawObjectId = "unresolved",
+                                clickCount = 90L,
+                                resolutionStatus = PopularNewsletterResolutionStatus.UNRESOLVED,
+                            ),
+                            SavePopularNewsletterSnapshotItemCommand(
+                                rank = 1,
+                                rawObjectId = "11",
+                                clickCount = 120L,
+                                resolvedContentId = 101L,
+                                resolvedExposureContentId = 11L,
+                                resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
+                            ),
+                        ),
+                ),
+            )
+
+        assertEquals(11L, assertNotNull(savedSnapshot).featuredExposureContentId)
+        assertEquals(11L, assertNotNull(result.featuredExposureContentId))
+    }
+
     private fun createSnapshot(
         id: Long,
         generatedAt: LocalDateTime,
         resolvedItemCount: Int,
+        featuredExposureContentId: Long? = null,
     ): PopularNewsletterSnapshot =
         PopularNewsletterSnapshot(
             id = id,
@@ -137,6 +163,7 @@ class PopularNewsletterSnapshotServiceTest {
             sourceEventName = "click_newsletter",
             candidateLimit = 20,
             resolvedItemCount = resolvedItemCount,
+            featuredExposureContentId = featuredExposureContentId,
             status = PopularNewsletterSnapshotStatus.SUCCESS,
         )
 }

--- a/external/src/test/kotlin/com/nexters/external/service/PopularNewsletterSnapshotServiceTest.kt
+++ b/external/src/test/kotlin/com/nexters/external/service/PopularNewsletterSnapshotServiceTest.kt
@@ -1,0 +1,142 @@
+package com.nexters.external.service
+
+import com.nexters.external.entity.Content
+import com.nexters.external.entity.ExposureContent
+import com.nexters.external.entity.PopularNewsletterSnapshot
+import com.nexters.external.entity.PopularNewsletterSnapshotItem
+import com.nexters.external.enums.PopularNewsletterResolutionStatus
+import com.nexters.external.enums.PopularNewsletterSegmentType
+import com.nexters.external.enums.PopularNewsletterSnapshotStatus
+import com.nexters.external.repository.ExposureContentRepository
+import com.nexters.external.repository.PopularNewsletterSnapshotItemRepository
+import com.nexters.external.repository.PopularNewsletterSnapshotRepository
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.Optional
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class PopularNewsletterSnapshotServiceTest {
+    private val popularNewsletterSnapshotRepository: PopularNewsletterSnapshotRepository =
+        Mockito.mock(PopularNewsletterSnapshotRepository::class.java)
+    private val popularNewsletterSnapshotItemRepository: PopularNewsletterSnapshotItemRepository =
+        Mockito.mock(PopularNewsletterSnapshotItemRepository::class.java)
+    private val exposureContentRepository: ExposureContentRepository =
+        Mockito.mock(ExposureContentRepository::class.java)
+
+    private val sut =
+        PopularNewsletterSnapshotService(
+            popularNewsletterSnapshotRepository = popularNewsletterSnapshotRepository,
+            popularNewsletterSnapshotItemRepository = popularNewsletterSnapshotItemRepository,
+            exposureContentRepository = exposureContentRepository,
+        )
+
+    @Test
+    fun `findLatestFeaturedExposureContent should fall back to older resolved snapshot`() {
+        val latestSnapshot =
+            createSnapshot(
+                id = 2L,
+                generatedAt = LocalDateTime.of(2026, 4, 18, 7, 30),
+                resolvedItemCount = 0,
+            )
+        val olderSnapshot =
+            createSnapshot(
+                id = 1L,
+                generatedAt = LocalDateTime.of(2026, 4, 17, 7, 30),
+                resolvedItemCount = 1,
+            )
+        val featuredExposureContent =
+            ExposureContent(
+                id = 11L,
+                content =
+                    Content(
+                        id = 101L,
+                        title = "title",
+                        content = "content",
+                        newsletterName = "newsletter",
+                        originalUrl = "https://example.com/articles/101",
+                        imageUrl = null,
+                        publishedAt = LocalDate.of(2026, 4, 18),
+                        contentProvider = null,
+                    ),
+                provocativeKeyword = "keyword",
+                provocativeHeadline = "headline",
+                summaryContent = "summary",
+            )
+        val olderResolvedItem =
+            PopularNewsletterSnapshotItem(
+                id = 21L,
+                snapshot = olderSnapshot,
+                rank = 1,
+                rawObjectId = "11",
+                clickCount = 120L,
+                resolvedContentId = 101L,
+                resolvedExposureContentId = 11L,
+                resolutionStatus = PopularNewsletterResolutionStatus.RESOLVED,
+            )
+
+        Mockito
+            .`when`(
+                popularNewsletterSnapshotRepository.findBySegmentTypeAndSegmentKeyAndStatusOrderByGeneratedAtDesc(
+                    PopularNewsletterSegmentType.GLOBAL,
+                    null,
+                    PopularNewsletterSnapshotStatus.SUCCESS,
+                ),
+            ).thenReturn(listOf(latestSnapshot, olderSnapshot))
+        Mockito
+            .`when`(
+                popularNewsletterSnapshotItemRepository.findFirstBySnapshotIdAndResolutionStatusOrderByRankAsc(
+                    1L,
+                    PopularNewsletterResolutionStatus.RESOLVED,
+                ),
+            ).thenReturn(olderResolvedItem)
+        Mockito
+            .`when`(exposureContentRepository.findById(11L))
+            .thenReturn(Optional.of(featuredExposureContent))
+
+        val result = sut.findLatestFeaturedExposureContent()
+
+        assertSame(featuredExposureContent, result)
+        Mockito
+            .verify(popularNewsletterSnapshotItemRepository, Mockito.never())
+            .findFirstBySnapshotIdAndResolutionStatusOrderByRankAsc(
+                2L,
+                PopularNewsletterResolutionStatus.RESOLVED,
+            )
+    }
+
+    @Test
+    fun `findLatestFeaturedExposureContent should return null when there is no resolved snapshot`() {
+        Mockito
+            .`when`(
+                popularNewsletterSnapshotRepository.findBySegmentTypeAndSegmentKeyAndStatusOrderByGeneratedAtDesc(
+                    PopularNewsletterSegmentType.GLOBAL,
+                    null,
+                    PopularNewsletterSnapshotStatus.SUCCESS,
+                ),
+            ).thenReturn(emptyList())
+
+        val result = sut.findLatestFeaturedExposureContent()
+
+        assertNull(result)
+    }
+
+    private fun createSnapshot(
+        id: Long,
+        generatedAt: LocalDateTime,
+        resolvedItemCount: Int,
+    ): PopularNewsletterSnapshot =
+        PopularNewsletterSnapshot(
+            id = id,
+            segmentType = PopularNewsletterSegmentType.GLOBAL,
+            windowStartDate = LocalDate.of(2025, 4, 19),
+            windowEndDate = LocalDate.of(2026, 4, 18),
+            generatedAt = generatedAt,
+            sourceEventName = "click_newsletter",
+            candidateLimit = 20,
+            resolvedItemCount = resolvedItemCount,
+            status = PopularNewsletterSnapshotStatus.SUCCESS,
+        )
+}

--- a/newsletter/src/main/kotlin/com/nexters/newsletter/resolver/PossibleContentsResolver.kt
+++ b/newsletter/src/main/kotlin/com/nexters/newsletter/resolver/PossibleContentsResolver.kt
@@ -1,5 +1,6 @@
 package com.nexters.newsletter.resolver
 
+import com.nexters.external.entity.ContentProvider
 import com.nexters.external.entity.ExposureContent
 import com.nexters.external.entity.ReservedKeyword
 import com.nexters.external.service.CategoryService
@@ -48,7 +49,7 @@ class PossibleContentsResolver(
         userId: Long,
         contentProviders: List<*>,
     ): List<ExposureContent> {
-        val contentProviderIds = contentProviders.mapNotNull { (it as? com.nexters.external.entity.ContentProvider)?.id }
+        val contentProviderIds = contentProviders.mapNotNull { (it as? ContentProvider)?.id }
         return if (contentProviderIds.isNotEmpty()) {
             exposureContentService.getNotExposedExposureContentsByContentProviderIds(userId, contentProviderIds)
         } else {

--- a/newsletter/src/main/kotlin/com/nexters/newsletter/service/RssContentService.kt
+++ b/newsletter/src/main/kotlin/com/nexters/newsletter/service/RssContentService.kt
@@ -14,6 +14,7 @@ import com.nexters.external.service.RssReaderService
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -29,7 +30,8 @@ class RssContentService(
 ) {
     private val logger = LoggerFactory.getLogger(RssContentService::class.java)
 
-    @Transactional
+    // feed의 DB 실패가 다음 feed까지 같은 세션을 오염시키지 않도록, feed 단위로 트랜잭션을 분리하여 처리
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     fun fetchAndSaveRssFeed(vararg feedUrls: String): Map<String, Int> =
         feedUrls.associateWith { feedUrl ->
             try {


### PR DESCRIPTION
## 요약

인기 뉴스레터를 GA 이벤트 기준으로 다시 집계해서 앱 응답에 노출할 수 있도록 했고, 작업 중 운영 DB에서 드러난 스키마 드리프트도 함께 정리했습니다.
이번 PR은 기능 추가와 스키마 보정을 같이 담고 있습니다.

## 주요 변경

- `click_newsletter` 이벤트 기준으로 인기 뉴스레터 랭킹을 집계하는 배치 로직을 추가했습니다.
- 집계 결과를 `popular_newsletter_snapshots`, `popular_newsletter_snapshot_items`에 저장하도록 했습니다.
- `rawObjectId`를 `contents` 또는 `exposure_contents`로 해석하는 매핑 로직을 추가했습니다.
- `/api/analytics/popular-newsletters/rebuild` 수동 재집계 API를 추가했습니다.
- `/api/newsletters/contents/{userId}` 응답에 `trendingCard`를 추가했습니다.
- RSS 수집 중 한 건의 DB 예외가 다음 feed 처리까지 전파되지 않도록 트랜잭션 경계를 조정했습니다.

## SQL 반영사항

### 1. `contents` 보정
기존 DB에 컬럼이 없어서 insert 실패하던 문제를 같이 정리했습니다.

- `newsletter_source_id` 컬럼을 `ADD COLUMN IF NOT EXISTS`로 보강
- `image_url` 컬럼을 `ADD COLUMN IF NOT EXISTS`로 보강
- `content_provider_id` 컬럼을 `ADD COLUMN IF NOT EXISTS`로 보강
- 아래 컬럼 타입을 길이 제한 없는 `TEXT`로 확장
- `title`
- `newsletter_name`
- `original_url`
- `image_url`

배경:
- `image_url` 컬럼 누락으로 insert 실패
- RSS/외부 데이터 길이로 인해 `varchar(255)` 초과 오류 발생

### 2. `rss_processing_status` 추가 및 보정
기존 DB에 테이블 자체가 없어서 RSS 처리 중 조회가 실패하던 문제를 반영했습니다.

- `rss_processing_status` 테이블 생성
- `newsletter_source_id` unique
- `item_url` unique
- `content_id`, `processing_error`, `priority`, `processed_at`, `ai_processed_at` 포함
- 아래 컬럼 타입을 `TEXT`로 확장
- `rss_url`
- `item_url`
- `title`
- 조회용 인덱스 추가
- `rss_url`
- `(ai_processed, is_processed, created_at DESC)`

### 3. 인기 뉴스레터 스냅샷 테이블 추가
GA 집계 결과를 보관하기 위한 신규 테이블입니다.

- `popular_newsletter_snapshots`
- 세그먼트 타입, 기간, 집계 시각, 이벤트명, 후보 개수, resolved 개수, 상태 저장
- `(segment_type, segment_key, generated_at DESC)` 인덱스 추가

- `popular_newsletter_snapshot_items`
- 스냅샷별 랭킹 아이템 저장
- `raw_object_id`, `click_count`, `resolved_content_id`, `resolved_exposure_content_id`, `resolution_status` 포함
- `(snapshot_id, rank_order)` unique 제약 추가
- `resolved_content_id -> contents.id` FK
- `resolved_exposure_content_id -> exposure_contents.id` FK
- `created_at`, `updated_at` 컬럼 포함

## 리뷰 포인트

- `schema.sql` 변경량이 많아서, 기존 운영 DB에 안전하게 적용되는지 먼저 봐주시면 좋겠습니다.
- 인기 뉴스레터 집계 결과가 `resolved_exposure_content_id`까지 안정적으로 연결되는지 확인 부탁드립니다.
- RSS 처리 트랜잭션 분리 방식이 현재 배치 실행 구조에 맞는지 같이 봐주시면 좋겠습니다.

## 확인

- `POST /api/analytics/popular-newsletters/rebuild`
- `GET /api/newsletters/contents/{userId}` 에서 `trendingCard` 확인
- RSS 수집 시 `rss_processing_status` / `contents` 관련 SQL 오류가 재발하지 않는지 확인
