### PR TITLE
feat: 탐색탭 필터링 기준 추가 (발행일)

### DIFF
--- a/api/src/main/kotlin/com/nexters/api/controller/NewsletterApiController.kt
+++ b/api/src/main/kotlin/com/nexters/api/controller/NewsletterApiController.kt
@@ -69,21 +69,22 @@ class NewsletterApiController(
     @GetMapping("/explore/contents")
     @Operation(
         summary = "탐색 콘텐츠 조회",
-        description =
-            "노출 콘텐츠 목록을 keyset cursor pagination으로 조회합니다. " +
-                "sort 없음(기본): 등록 ID 내림차순. sort=published: 발행일(published_at) 내림차순, 동일 발행일은 ID 내림차순. " +
-                "다음 페이지 조회 시 응답의 nextOffset을 lastSeenOffset에 전달합니다.",
+        description = """
+            노출 콘텐츠 목록을 keyset cursor pagination으로 조회합니다.
+            sort 없음(기본): 등록 ID 내림차순. sort=published: 발행일(published_at) 내림차순, 동일 발행일은 ID 내림차순.
+            다음 페이지 조회 시 응답의 nextOffset을 lastSeenOffset에 전달합니다.
+        """,
     )
     fun getExploreContents(
         @Parameter(description = "이전 페이지 응답의 nextOffset 값. 첫 페이지는 0(기본값).", example = "0")
         @RequestParam(defaultValue = "0") lastSeenOffset: Long,
         @Parameter(description = "한 번에 가져올 콘텐츠 개수. 1 이상 값만 허용합니다. (기본값: 20)", example = "20")
         @RequestParam(defaultValue = "20") size: Int,
-        @Parameter(description = "정렬 기준 (published: 발행일 최신순)", example = "published")
-        @RequestParam(required = false) sort: String?,
+        @Parameter(description = "정렬 기준 (PUBLISHED: 발행일 최신순)", example = "PUBLISHED")
+        @RequestParam(required = false) sort: ExploreSortType?,
     ): ExposureContentListApiResponse =
         newsletterExploreService
-            .getExploreContents(lastSeenOffset, size, ExploreSortType.from(sort))
+            .getExploreContents(lastSeenOffset, size, sort ?: ExploreSortType.REGISTERED)
             .toApiResponse()
 
     @PostMapping("/contents")

--- a/api/src/main/kotlin/com/nexters/api/controller/NewsletterApiController.kt
+++ b/api/src/main/kotlin/com/nexters/api/controller/NewsletterApiController.kt
@@ -69,9 +69,10 @@ class NewsletterApiController(
     @GetMapping("/explore/contents")
     @Operation(
         summary = "탐색 콘텐츠 조회",
-        description = "노출 콘텐츠 목록을 keyset cursor pagination으로 조회합니다. " +
-            "sort 없음(기본): 등록 ID 내림차순. sort=published: 발행일(published_at) 내림차순, 동일 발행일은 ID 내림차순. " +
-            "다음 페이지 조회 시 응답의 nextOffset을 lastSeenOffset에 전달합니다.",
+        description =
+            "노출 콘텐츠 목록을 keyset cursor pagination으로 조회합니다. " +
+                "sort 없음(기본): 등록 ID 내림차순. sort=published: 발행일(published_at) 내림차순, 동일 발행일은 ID 내림차순. " +
+                "다음 페이지 조회 시 응답의 nextOffset을 lastSeenOffset에 전달합니다.",
     )
     fun getExploreContents(
         @Parameter(description = "이전 페이지 응답의 nextOffset 값. 첫 페이지는 0(기본값).", example = "0")

--- a/api/src/main/kotlin/com/nexters/api/controller/NewsletterApiController.kt
+++ b/api/src/main/kotlin/com/nexters/api/controller/NewsletterApiController.kt
@@ -7,6 +7,7 @@ import com.nexters.api.dto.CreateContentApiResponse
 import com.nexters.api.dto.CreateContentProviderRequestApiRequest
 import com.nexters.api.dto.ExposureContentApiResponse
 import com.nexters.api.dto.ExposureContentListApiResponse
+import com.nexters.api.enums.ExploreSortType
 import com.nexters.api.enums.Language
 import com.nexters.api.exception.UnauthorizedException
 import com.nexters.api.service.ExploreContentResult
@@ -68,16 +69,20 @@ class NewsletterApiController(
     @GetMapping("/explore/contents")
     @Operation(
         summary = "탐색 콘텐츠 조회",
-        description = "노출 콘텐츠 목록을 id DESC 기준 keyset pagination으로 조회합니다. 다음 페이지는 lastSeenOffset보다 작은 id만 조회하여 이전 페이지와 중복되지 않습니다.",
+        description = "노출 콘텐츠 목록을 keyset cursor pagination으로 조회합니다. " +
+            "sort 없음(기본): 등록 ID 내림차순. sort=published: 발행일(published_at) 내림차순, 동일 발행일은 ID 내림차순. " +
+            "다음 페이지 조회 시 응답의 nextOffset을 lastSeenOffset에 전달합니다.",
     )
     fun getExploreContents(
-        @Parameter(description = "마지막으로 본 노출 콘텐츠 ID. 다음 페이지 조회 시 이 ID는 제외됩니다. (기본값: 0)", example = "0")
+        @Parameter(description = "이전 페이지 응답의 nextOffset 값. 첫 페이지는 0(기본값).", example = "0")
         @RequestParam(defaultValue = "0") lastSeenOffset: Long,
         @Parameter(description = "한 번에 가져올 콘텐츠 개수. 1 이상 값만 허용합니다. (기본값: 20)", example = "20")
         @RequestParam(defaultValue = "20") size: Int,
+        @Parameter(description = "정렬 기준 (published: 발행일 최신순)", example = "published")
+        @RequestParam(required = false) sort: String?,
     ): ExposureContentListApiResponse =
         newsletterExploreService
-            .getExploreContents(lastSeenOffset, size)
+            .getExploreContents(lastSeenOffset, size, ExploreSortType.from(sort))
             .toApiResponse()
 
     @PostMapping("/contents")

--- a/api/src/main/kotlin/com/nexters/api/enums/ExploreSortType.kt
+++ b/api/src/main/kotlin/com/nexters/api/enums/ExploreSortType.kt
@@ -1,0 +1,16 @@
+package com.nexters.api.enums
+
+enum class ExploreSortType {
+    REGISTERED,
+    PUBLISHED,
+    ;
+
+    companion object {
+        fun from(value: String?): ExploreSortType =
+            when (value) {
+                null -> REGISTERED
+                "published" -> PUBLISHED
+                else -> throw IllegalArgumentException("Invalid sort value: '$value'. Allowed values: published")
+            }
+    }
+}

--- a/api/src/main/kotlin/com/nexters/api/enums/ExploreSortType.kt
+++ b/api/src/main/kotlin/com/nexters/api/enums/ExploreSortType.kt
@@ -3,14 +3,4 @@ package com.nexters.api.enums
 enum class ExploreSortType {
     REGISTERED,
     PUBLISHED,
-    ;
-
-    companion object {
-        fun from(value: String?): ExploreSortType =
-            when (value) {
-                null -> REGISTERED
-                "published" -> PUBLISHED
-                else -> throw IllegalArgumentException("Invalid sort value: '$value'. Allowed values: published")
-            }
-    }
 }

--- a/api/src/main/kotlin/com/nexters/api/service/NewsletterExploreService.kt
+++ b/api/src/main/kotlin/com/nexters/api/service/NewsletterExploreService.kt
@@ -34,10 +34,11 @@ class NewsletterExploreService(
         sortType: ExploreSortType,
     ): ExploreContentPageResult =
         when (sortType) {
-            ExploreSortType.REGISTERED -> when (lastSeenOffset) {
-                FIRST_PAGE_OFFSET -> findCachedFirstExploreContentPage(size)
-                else -> loadPage(lastSeenOffset, size, exposureContentService::getExploreContentRows)
-            }
+            ExploreSortType.REGISTERED ->
+                when (lastSeenOffset) {
+                    FIRST_PAGE_OFFSET -> findCachedFirstExploreContentPage(size)
+                    else -> loadPage(lastSeenOffset, size, exposureContentService::getExploreContentRows)
+                }
             // PUBLISHED 정렬은 첫 페이지도 캐싱하지 않는다.
             // 최신 콘텐츠가 수시로 추가되고, 발행일 기준 정렬을 선택한 사용자에게 오래된 글을 보여주면 의미가 없어지기 때문.
             ExploreSortType.PUBLISHED -> loadPage(lastSeenOffset, size, exposureContentService::getExploreContentRowsSortedByPublishedAt)

--- a/api/src/main/kotlin/com/nexters/api/service/NewsletterExploreService.kt
+++ b/api/src/main/kotlin/com/nexters/api/service/NewsletterExploreService.kt
@@ -13,7 +13,7 @@ class NewsletterExploreService(
     fun getExploreContents(
         lastSeenOffset: Long,
         size: Int,
-        sortType: ExploreSortType = ExploreSortType.REGISTERED,
+        sortType: ExploreSortType,
     ): ExploreContentsResult {
         validateRequest(lastSeenOffset, size)
 
@@ -32,24 +32,29 @@ class NewsletterExploreService(
         lastSeenOffset: Long,
         size: Int,
         sortType: ExploreSortType,
-    ): ExploreContentPageResult =
-        when (sortType) {
-            ExploreSortType.REGISTERED ->
-                when (lastSeenOffset) {
-                    FIRST_PAGE_OFFSET -> findCachedFirstExploreContentPage(size)
-                    else -> loadPage(lastSeenOffset, size, exposureContentService::getExploreContentRows)
-                }
-            // PUBLISHED 정렬은 첫 페이지도 캐싱하지 않는다.
-            // 최신 콘텐츠가 수시로 추가되고, 발행일 기준 정렬을 선택한 사용자에게 오래된 글을 보여주면 의미가 없어지기 때문.
-            ExploreSortType.PUBLISHED -> loadPage(lastSeenOffset, size, exposureContentService::getExploreContentRowsSortedByPublishedAt)
+    ): ExploreContentPageResult {
+        val fetcher =
+            when (sortType) {
+                ExploreSortType.REGISTERED -> exposureContentService::getExploreContentRows
+                ExploreSortType.PUBLISHED -> exposureContentService::getExploreContentRowsSortedByPublishedAt
+            }
+        return if (lastSeenOffset == FIRST_PAGE_OFFSET) {
+            findCachedFirstExploreContentPage(sortType, size, fetcher)
+        } else {
+            loadPage(lastSeenOffset, size, fetcher)
         }
+    }
 
-    private fun findCachedFirstExploreContentPage(size: Int): ExploreContentPageResult =
+    private fun findCachedFirstExploreContentPage(
+        sortType: ExploreSortType,
+        size: Int,
+        fetch: (Long, Int) -> List<ExploreContentRow>,
+    ): ExploreContentPageResult =
         LocalCache.getOrPut(
-            key = buildExploreContentPageCacheKey(size),
+            key = buildExploreContentPageCacheKey(sortType, size),
             ttl = EXPOSURE_CONTENTS_CACHE_TTL_MINUTES,
         ) {
-            loadPage(FIRST_PAGE_OFFSET, size, exposureContentService::getExploreContentRows)
+            loadPage(FIRST_PAGE_OFFSET, size, fetch)
         }
 
     private fun countExposureContents(): Long =
@@ -109,7 +114,9 @@ class NewsletterExploreService(
         private const val TOTAL_COUNT_CACHE_KEY = "$CACHE_KEY_PREFIX:total-count"
         private const val PAGE_CACHE_KEY_PREFIX = "$CACHE_KEY_PREFIX:page:"
 
-        private fun buildExploreContentPageCacheKey(size: Int): String =
-            "${PAGE_CACHE_KEY_PREFIX}last-seen-offset:$FIRST_PAGE_OFFSET:size:$size"
+        private fun buildExploreContentPageCacheKey(
+            sortType: ExploreSortType,
+            size: Int
+        ): String = "${PAGE_CACHE_KEY_PREFIX}sort:${sortType.name}:size:$size"
     }
 }

--- a/api/src/main/kotlin/com/nexters/api/service/NewsletterExploreService.kt
+++ b/api/src/main/kotlin/com/nexters/api/service/NewsletterExploreService.kt
@@ -1,5 +1,6 @@
 package com.nexters.api.service
 
+import com.nexters.api.enums.ExploreSortType
 import com.nexters.api.util.LocalCache
 import com.nexters.external.repository.ExploreContentRow
 import com.nexters.external.service.ExposureContentService
@@ -12,10 +13,11 @@ class NewsletterExploreService(
     fun getExploreContents(
         lastSeenOffset: Long,
         size: Int,
+        sortType: ExploreSortType = ExploreSortType.REGISTERED,
     ): ExploreContentsResult {
         validateRequest(lastSeenOffset, size)
 
-        val page = findExploreContentPage(lastSeenOffset, size)
+        val page = findExploreContentPage(lastSeenOffset, size, sortType)
         val totalCount = countExposureContents()
 
         return ExploreContentsResult(
@@ -29,10 +31,16 @@ class NewsletterExploreService(
     private fun findExploreContentPage(
         lastSeenOffset: Long,
         size: Int,
+        sortType: ExploreSortType,
     ): ExploreContentPageResult =
-        when (lastSeenOffset) {
-            FIRST_PAGE_OFFSET -> findCachedFirstExploreContentPage(size)
-            else -> loadExploreContentPage(lastSeenOffset, size)
+        when (sortType) {
+            ExploreSortType.REGISTERED -> when (lastSeenOffset) {
+                FIRST_PAGE_OFFSET -> findCachedFirstExploreContentPage(size)
+                else -> loadPage(lastSeenOffset, size, exposureContentService::getExploreContentRows)
+            }
+            // PUBLISHED 정렬은 첫 페이지도 캐싱하지 않는다.
+            // 최신 콘텐츠가 수시로 추가되고, 발행일 기준 정렬을 선택한 사용자에게 오래된 글을 보여주면 의미가 없어지기 때문.
+            ExploreSortType.PUBLISHED -> loadPage(lastSeenOffset, size, exposureContentService::getExploreContentRowsSortedByPublishedAt)
         }
 
     private fun findCachedFirstExploreContentPage(size: Int): ExploreContentPageResult =
@@ -40,7 +48,7 @@ class NewsletterExploreService(
             key = buildExploreContentPageCacheKey(size),
             ttl = EXPOSURE_CONTENTS_CACHE_TTL_MINUTES,
         ) {
-            loadExploreContentPage(FIRST_PAGE_OFFSET, size)
+            loadPage(FIRST_PAGE_OFFSET, size, exposureContentService::getExploreContentRows)
         }
 
     private fun countExposureContents(): Long =
@@ -50,17 +58,14 @@ class NewsletterExploreService(
             loader = exposureContentService::countAllExposureContents,
         )
 
-    private fun loadExploreContentPage(
+    private fun loadPage(
         lastSeenOffset: Long,
         size: Int,
+        fetch: (Long, Int) -> List<ExploreContentRow>,
     ): ExploreContentPageResult {
-        val rows = exposureContentService.getExploreContentRows(lastSeenOffset, size + 1)
-        val contents =
-            rows
-                .take(size)
-                .map { it.toResult() }
+        val rows = fetch(lastSeenOffset, size + 1)
+        val contents = rows.take(size).map { it.toResult() }
         val hasMore = rows.size > size
-
         return ExploreContentPageResult(
             contents = contents,
             hasMore = hasMore,

--- a/api/src/test/kotlin/com/nexters/api/service/NewsletterExploreServiceTest.kt
+++ b/api/src/test/kotlin/com/nexters/api/service/NewsletterExploreServiceTest.kt
@@ -1,5 +1,6 @@
 package com.nexters.api.service
 
+import com.nexters.api.enums.ExploreSortType
 import com.nexters.api.util.LocalCache
 import com.nexters.external.repository.ExploreContentRow
 import com.nexters.external.service.ExposureContentService
@@ -37,8 +38,8 @@ class NewsletterExploreServiceTest {
             .`when`(exposureContentService.countAllExposureContents())
             .thenReturn(2L)
 
-        val first = sut.getExploreContents(lastSeenOffset = 0L, size = 2)
-        val second = sut.getExploreContents(lastSeenOffset = 0L, size = 2)
+        val first = sut.getExploreContents(lastSeenOffset = 0L, size = 2, sortType = ExploreSortType.REGISTERED)
+        val second = sut.getExploreContents(lastSeenOffset = 0L, size = 2, sortType = ExploreSortType.REGISTERED)
 
         assertThat(first).isEqualTo(second)
         assertThat(first.contents).hasSize(2)
@@ -65,8 +66,8 @@ class NewsletterExploreServiceTest {
             .`when`(exposureContentService.countAllExposureContents())
             .thenReturn(3L)
 
-        val first = sut.getExploreContents(lastSeenOffset = 0L, size = 2)
-        val second = sut.getExploreContents(lastSeenOffset = 20L, size = 2)
+        val first = sut.getExploreContents(lastSeenOffset = 0L, size = 2, sortType = ExploreSortType.REGISTERED)
+        val second = sut.getExploreContents(lastSeenOffset = 20L, size = 2, sortType = ExploreSortType.REGISTERED)
 
         assertThat(first.hasMore).isTrue()
         assertThat(first.nextOffset).isEqualTo(20L)
@@ -92,8 +93,8 @@ class NewsletterExploreServiceTest {
             .`when`(exposureContentService.countAllExposureContents())
             .thenReturn(3L)
 
-        val first = sut.getExploreContents(lastSeenOffset = 20L, size = 2)
-        val second = sut.getExploreContents(lastSeenOffset = 20L, size = 2)
+        val first = sut.getExploreContents(lastSeenOffset = 20L, size = 2, sortType = ExploreSortType.REGISTERED)
+        val second = sut.getExploreContents(lastSeenOffset = 20L, size = 2, sortType = ExploreSortType.REGISTERED)
 
         assertThat(first.contents.map { it.id }).containsExactly(10L)
         assertThat(second.contents.map { it.id }).containsExactly(10L)
@@ -117,12 +118,81 @@ class NewsletterExploreServiceTest {
             .`when`(exposureContentService.countAllExposureContents())
             .thenReturn(4L)
 
-        val firstPage = sut.getExploreContents(lastSeenOffset = 0L, size = 2)
-        val secondPage = sut.getExploreContents(lastSeenOffset = firstPage.nextOffset!!, size = 2)
+        val firstPage = sut.getExploreContents(lastSeenOffset = 0L, size = 2, sortType = ExploreSortType.REGISTERED)
+        val secondPage = sut.getExploreContents(lastSeenOffset = firstPage.nextOffset!!, size = 2, sortType = ExploreSortType.REGISTERED)
 
         assertThat(firstPage.contents.map { it.id }).containsExactly(50L, 40L)
         assertThat(secondPage.contents.map { it.id }).containsExactly(30L, 20L)
         assertThat(firstPage.contents.map { it.id }).doesNotContainAnyElementsOf(secondPage.contents.map { it.id })
+    }
+
+    @Test
+    fun `PUBLISHED sort first page should reuse cached page`() {
+        Mockito
+            .`when`(exposureContentService.getExploreContentRowsSortedByPublishedAt(0L, 3))
+            .thenReturn(listOf(exploreRow(id = 20L), exploreRow(id = 10L)))
+        Mockito
+            .`when`(exposureContentService.countAllExposureContents())
+            .thenReturn(2L)
+
+        val first = sut.getExploreContents(lastSeenOffset = 0L, size = 2, sortType = ExploreSortType.PUBLISHED)
+        val second = sut.getExploreContents(lastSeenOffset = 0L, size = 2, sortType = ExploreSortType.PUBLISHED)
+
+        assertThat(first).isEqualTo(second)
+        Mockito
+            .verify(exposureContentService, Mockito.times(1))
+            .getExploreContentRowsSortedByPublishedAt(0L, 3)
+    }
+
+    @Test
+    fun `REGISTERED and PUBLISHED sort should not share cache`() {
+        Mockito
+            .`when`(exposureContentService.getExploreContentRows(0L, 3))
+            .thenReturn(listOf(exploreRow(id = 10L), exploreRow(id = 5L)))
+        Mockito
+            .`when`(exposureContentService.getExploreContentRowsSortedByPublishedAt(0L, 3))
+            .thenReturn(listOf(exploreRow(id = 20L), exploreRow(id = 10L)))
+        Mockito
+            .`when`(exposureContentService.countAllExposureContents())
+            .thenReturn(2L)
+
+        val registered = sut.getExploreContents(lastSeenOffset = 0L, size = 2, sortType = ExploreSortType.REGISTERED)
+        val published = sut.getExploreContents(lastSeenOffset = 0L, size = 2, sortType = ExploreSortType.PUBLISHED)
+
+        assertThat(registered.contents.map { it.id }).containsExactly(10L, 5L)
+        assertThat(published.contents.map { it.id }).containsExactly(20L, 10L)
+        Mockito
+            .verify(exposureContentService, Mockito.times(1))
+            .getExploreContentRows(0L, 3)
+        Mockito
+            .verify(exposureContentService, Mockito.times(1))
+            .getExploreContentRowsSortedByPublishedAt(0L, 3)
+    }
+
+    @Test
+    fun `PUBLISHED sort next page should use publishedAt fetcher not registered fetcher`() {
+        Mockito
+            .`when`(exposureContentService.getExploreContentRowsSortedByPublishedAt(0L, 3))
+            .thenReturn(listOf(exploreRow(id = 30L), exploreRow(id = 20L), exploreRow(id = 10L)))
+        Mockito
+            .`when`(exposureContentService.getExploreContentRowsSortedByPublishedAt(20L, 3))
+            .thenReturn(listOf(exploreRow(id = 10L)))
+        Mockito
+            .`when`(exposureContentService.countAllExposureContents())
+            .thenReturn(3L)
+
+        val first = sut.getExploreContents(lastSeenOffset = 0L, size = 2, sortType = ExploreSortType.PUBLISHED)
+        val second = sut.getExploreContents(lastSeenOffset = first.nextOffset!!, size = 2, sortType = ExploreSortType.PUBLISHED)
+
+        assertThat(first.hasMore).isTrue()
+        assertThat(second.contents.map { it.id }).containsExactly(10L)
+        assertThat(second.hasMore).isFalse()
+        Mockito
+            .verify(exposureContentService, Mockito.never())
+            .getExploreContentRows(Mockito.anyLong(), Mockito.anyInt())
+        Mockito
+            .verify(exposureContentService, Mockito.times(2))
+            .getExploreContentRowsSortedByPublishedAt(Mockito.anyLong(), Mockito.eq(3))
     }
 
     @Test
@@ -136,9 +206,9 @@ class NewsletterExploreServiceTest {
             .thenReturn(2L)
             .thenReturn(3L)
 
-        val cached = sut.getExploreContents(lastSeenOffset = 0L, size = 2)
+        val cached = sut.getExploreContents(lastSeenOffset = 0L, size = 2, sortType = ExploreSortType.REGISTERED)
         deleteExploreCacheKeys()
-        val reloaded = sut.getExploreContents(lastSeenOffset = 0L, size = 2)
+        val reloaded = sut.getExploreContents(lastSeenOffset = 0L, size = 2, sortType = ExploreSortType.REGISTERED)
 
         assertThat(cached.contents.map { it.id }).containsExactly(20L, 10L)
         assertThat(cached.totalCount).isEqualTo(2L)

--- a/external/src/main/kotlin/com/nexters/external/repository/ExposureContentRepository.kt
+++ b/external/src/main/kotlin/com/nexters/external/repository/ExposureContentRepository.kt
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 
 @Repository
 interface ExposureContentRepository : JpaRepository<ExposureContent, Long> {
@@ -133,6 +134,58 @@ interface ExposureContentRepository : JpaRepository<ExposureContent, Long> {
     )
     fun findExploreRowsAfter(
         @Param("lastSeenOffset") lastSeenOffset: Long,
+        pageable: Pageable,
+    ): List<ExploreContentRow>
+
+    @Query(
+        """
+        SELECT new com.nexters.external.repository.ExploreContentRow(
+            e.id,
+            c.id,
+            e.provocativeKeyword,
+            e.provocativeHeadline,
+            e.summaryContent,
+            c.originalUrl,
+            c.imageUrl,
+            c.newsletterName,
+            cp.language,
+            e.createdAt,
+            e.updatedAt
+        )
+        FROM ExposureContent e
+        JOIN e.content c
+        LEFT JOIN c.contentProvider cp
+        ORDER BY c.publishedAt DESC, e.id DESC
+    """,
+    )
+    fun findExploreRowsSortedByPublishedAt(pageable: Pageable): List<ExploreContentRow>
+
+    @Query(
+        """
+        SELECT new com.nexters.external.repository.ExploreContentRow(
+            e.id,
+            c.id,
+            e.provocativeKeyword,
+            e.provocativeHeadline,
+            e.summaryContent,
+            c.originalUrl,
+            c.imageUrl,
+            c.newsletterName,
+            cp.language,
+            e.createdAt,
+            e.updatedAt
+        )
+        FROM ExposureContent e
+        JOIN e.content c
+        LEFT JOIN c.contentProvider cp
+        WHERE c.publishedAt < :lastSeenPublishedAt
+           OR (c.publishedAt = :lastSeenPublishedAt AND e.id < :lastSeenId)
+        ORDER BY c.publishedAt DESC, e.id DESC
+    """,
+    )
+    fun findExploreRowsSortedByPublishedAtAfter(
+        @Param("lastSeenPublishedAt") lastSeenPublishedAt: LocalDate,
+        @Param("lastSeenId") lastSeenId: Long,
         pageable: Pageable,
     ): List<ExploreContentRow>
 

--- a/external/src/main/kotlin/com/nexters/external/repository/ExposureContentRepository.kt
+++ b/external/src/main/kotlin/com/nexters/external/repository/ExposureContentRepository.kt
@@ -105,7 +105,6 @@ interface ExposureContentRepository : JpaRepository<ExposureContent, Long> {
         FROM ExposureContent e
         JOIN e.content c
         LEFT JOIN c.contentProvider cp
-        ORDER BY e.id DESC
     """,
     )
     fun findExploreRows(pageable: Pageable): List<ExploreContentRow>
@@ -129,7 +128,6 @@ interface ExposureContentRepository : JpaRepository<ExposureContent, Long> {
         JOIN e.content c
         LEFT JOIN c.contentProvider cp
         WHERE e.id < :lastSeenOffset
-        ORDER BY e.id DESC
     """,
     )
     fun findExploreRowsAfter(
@@ -155,35 +153,11 @@ interface ExposureContentRepository : JpaRepository<ExposureContent, Long> {
         FROM ExposureContent e
         JOIN e.content c
         LEFT JOIN c.contentProvider cp
-        ORDER BY c.publishedAt DESC, e.id DESC
-    """,
-    )
-    fun findExploreRowsSortedByPublishedAt(pageable: Pageable): List<ExploreContentRow>
-
-    @Query(
-        """
-        SELECT new com.nexters.external.repository.ExploreContentRow(
-            e.id,
-            c.id,
-            e.provocativeKeyword,
-            e.provocativeHeadline,
-            e.summaryContent,
-            c.originalUrl,
-            c.imageUrl,
-            c.newsletterName,
-            cp.language,
-            e.createdAt,
-            e.updatedAt
-        )
-        FROM ExposureContent e
-        JOIN e.content c
-        LEFT JOIN c.contentProvider cp
         WHERE c.publishedAt < :lastSeenPublishedAt
            OR (c.publishedAt = :lastSeenPublishedAt AND e.id < :lastSeenId)
-        ORDER BY c.publishedAt DESC, e.id DESC
     """,
     )
-    fun findExploreRowsSortedByPublishedAtAfter(
+    fun findExploreRowsAfterByPublishedAt(
         @Param("lastSeenPublishedAt") lastSeenPublishedAt: LocalDate,
         @Param("lastSeenId") lastSeenId: Long,
         pageable: Pageable,

--- a/external/src/main/kotlin/com/nexters/external/repository/ExposureContentRepository.kt
+++ b/external/src/main/kotlin/com/nexters/external/repository/ExposureContentRepository.kt
@@ -154,12 +154,10 @@ interface ExposureContentRepository : JpaRepository<ExposureContent, Long> {
         JOIN e.content c
         LEFT JOIN c.contentProvider cp
         WHERE c.publishedAt < :lastSeenPublishedAt
-           OR (c.publishedAt = :lastSeenPublishedAt AND e.id < :lastSeenId)
     """,
     )
     fun findExploreRowsAfterByPublishedAt(
         @Param("lastSeenPublishedAt") lastSeenPublishedAt: LocalDate,
-        @Param("lastSeenId") lastSeenId: Long,
         pageable: Pageable,
     ): List<ExploreContentRow>
 

--- a/external/src/main/kotlin/com/nexters/external/service/ExposureContentService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/ExposureContentService.kt
@@ -127,6 +127,22 @@ class ExposureContentService(
         }
     }
 
+    @Transactional(readOnly = true)
+    fun getExploreContentRowsSortedByPublishedAt(
+        lastSeenOffset: Long,
+        limit: Int,
+    ): List<ExploreContentRow> {
+        val pageable = PageRequest.of(0, limit)
+        if (lastSeenOffset == 0L) return exposureContentRepository.findExploreRowsSortedByPublishedAt(pageable)
+        val lastSeen = exposureContentRepository.findById(lastSeenOffset)
+            .orElseThrow { NoSuchElementException("Exposure content not found: $lastSeenOffset") }
+        return exposureContentRepository.findExploreRowsSortedByPublishedAtAfter(
+            lastSeen.content.publishedAt,
+            lastSeenOffset,
+            pageable,
+        )
+    }
+
     fun getAllExposureContentsPaged(pageable: Pageable): Page<ExposureContent> = exposureContentRepository.findAllPaged(pageable)
 
     fun getExposureContentsByKeywordPaged(

--- a/external/src/main/kotlin/com/nexters/external/service/ExposureContentService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/ExposureContentService.kt
@@ -134,8 +134,10 @@ class ExposureContentService(
     ): List<ExploreContentRow> {
         val pageable = PageRequest.of(0, limit)
         if (lastSeenOffset == 0L) return exposureContentRepository.findExploreRowsSortedByPublishedAt(pageable)
-        val lastSeen = exposureContentRepository.findById(lastSeenOffset)
-            .orElseThrow { NoSuchElementException("Exposure content not found: $lastSeenOffset") }
+        val lastSeen =
+            exposureContentRepository
+                .findById(lastSeenOffset)
+                .orElseThrow { NoSuchElementException("Exposure content not found: $lastSeenOffset") }
         return exposureContentRepository.findExploreRowsSortedByPublishedAtAfter(
             lastSeen.content.publishedAt,
             lastSeenOffset,

--- a/external/src/main/kotlin/com/nexters/external/service/ExposureContentService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/ExposureContentService.kt
@@ -12,6 +12,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.domain.JpaSort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -119,7 +121,7 @@ class ExposureContentService(
         lastSeenOffset: Long,
         limit: Int,
     ): List<ExploreContentRow> {
-        val pageable = PageRequest.of(0, limit)
+        val pageable = PageRequest.of(0, limit, REGISTERED_SORT)
         return if (lastSeenOffset == 0L) {
             exposureContentRepository.findExploreRows(pageable)
         } else {
@@ -132,13 +134,13 @@ class ExposureContentService(
         lastSeenOffset: Long,
         limit: Int,
     ): List<ExploreContentRow> {
-        val pageable = PageRequest.of(0, limit)
-        if (lastSeenOffset == 0L) return exposureContentRepository.findExploreRowsSortedByPublishedAt(pageable)
+        val pageable = PageRequest.of(0, limit, PUBLISHED_SORT)
+        if (lastSeenOffset == 0L) return exposureContentRepository.findExploreRows(pageable)
         val lastSeen =
             exposureContentRepository
                 .findById(lastSeenOffset)
                 .orElseThrow { NoSuchElementException("Exposure content not found: $lastSeenOffset") }
-        return exposureContentRepository.findExploreRowsSortedByPublishedAtAfter(
+        return exposureContentRepository.findExploreRowsAfterByPublishedAt(
             lastSeen.content.publishedAt,
             lastSeenOffset,
             pageable,
@@ -249,4 +251,12 @@ class ExposureContentService(
     ): List<ExposureContent> = exposureContentRepository.findNotExposedByContentProviderIds(userId, contentProviderIds)
 
     fun countAllExposureContents(): Long = exposureContentRepository.count()
+
+    companion object {
+        private val REGISTERED_SORT: Sort = JpaSort.unsafe(Sort.Direction.DESC, "e.id")
+        private val PUBLISHED_SORT: Sort =
+            JpaSort
+                .unsafe(Sort.Direction.DESC, "c.publishedAt")
+                .and(JpaSort.unsafe(Sort.Direction.DESC, "e.id"))
+    }
 }

--- a/external/src/main/kotlin/com/nexters/external/service/ExposureContentService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/ExposureContentService.kt
@@ -142,7 +142,6 @@ class ExposureContentService(
                 .orElseThrow { NoSuchElementException("Exposure content not found: $lastSeenOffset") }
         return exposureContentRepository.findExploreRowsAfterByPublishedAt(
             lastSeen.content.publishedAt,
-            lastSeenOffset,
             pageable,
         )
     }

--- a/external/src/test/kotlin/com/nexters/external/repository/ExposureContentRepositoryTest.kt
+++ b/external/src/test/kotlin/com/nexters/external/repository/ExposureContentRepositoryTest.kt
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.domain.JpaSort
 import java.time.LocalDate
 
 @DataJpaTest
@@ -38,11 +40,12 @@ class ExposureContentRepositoryTest {
         entityManager.flush()
         entityManager.clear()
 
-        val rows = repository.findExploreRows(PageRequest.of(0, 2))
+        val byIdDesc = JpaSort.unsafe(Sort.Direction.DESC, "e.id")
+        val rows = repository.findExploreRows(PageRequest.of(0, 2, byIdDesc))
         val rowsAfterNewest =
             repository.findExploreRowsAfter(
                 lastSeenOffset = secondExposureContent.id!!,
-                pageable = PageRequest.of(0, 2),
+                pageable = PageRequest.of(0, 2, byIdDesc),
             )
 
         assertThat(rows).hasSize(2)


### PR DESCRIPTION
## 작업 내용

탐색탭 발행일 기준 필터링 조회를 위한 파라미터 추가 (GET /api/newsletters/explore/contents?sort=published)

## 작업 상세

- sort 파라미터 추가 -> 발행일(published_at) 내림차순, 동일 발행일은 ID 내림차순
- 정렬 기준 enum 추가 (ExploreSortType)
- 두 정렬 기준의 페이징 로직 통합 (loadPage)
- sort=published는 첫페이지 캐싱 X
- published_at 인덱스 미적용 근거 -> cardinality 11.9%(4093건 중 고유값 487개)