### PR TITLE
직군 카테고리별 컨텐츠 필터링

### DIFF
--- a/api/src/main/kotlin/com/nexters/api/controller/NewsletterApiController.kt
+++ b/api/src/main/kotlin/com/nexters/api/controller/NewsletterApiController.kt
@@ -75,6 +75,7 @@ class NewsletterApiController(
             sort 없음(기본): 등록 ID 기준. sort=published: 발행일(published_at) 기준.
             direction 없음(기본): DESC. direction=ASC로 오래된 순서 조회가 가능합니다.
             다음 페이지 조회 시 응답의 nextOffset을 lastSeenOffset에 전달합니다.
+            categoryIds 지정 시 해당 직군 카테고리의 콘텐츠만 필터링됩니다. 미지정 시 전체 조회.
         """,
     )
     fun getExploreContents(
@@ -86,9 +87,11 @@ class NewsletterApiController(
         @RequestParam(required = false) sort: ExploreSortType?,
         @Parameter(description = "정렬 방향 (DESC: 최신순, ASC: 오래된 순)", example = "DESC")
         @RequestParam(defaultValue = "DESC") direction: Sort.Direction,
+        @Parameter(description = "직군 카테고리 ID 목록. 미지정 시 전체 조회.", example = "2")
+        @RequestParam(required = false) categoryIds: List<Long>?,
     ): ExposureContentListApiResponse =
         newsletterExploreService
-            .getExploreContents(lastSeenOffset, size, sort ?: ExploreSortType.REGISTERED, direction)
+            .getExploreContents(lastSeenOffset, size, sort ?: ExploreSortType.REGISTERED, direction, categoryIds)
             .toApiResponse()
 
     @PostMapping("/contents")

--- a/api/src/main/kotlin/com/nexters/api/service/NewsletterExploreService.kt
+++ b/api/src/main/kotlin/com/nexters/api/service/NewsletterExploreService.kt
@@ -16,11 +16,18 @@ class NewsletterExploreService(
         size: Int,
         sortType: ExploreSortType,
         direction: Sort.Direction = Sort.Direction.DESC,
+        categoryIds: List<Long>? = null,
     ): ExploreContentsResult {
         validateRequest(lastSeenOffset, size)
 
-        val page = findExploreContentPage(lastSeenOffset, size, sortType, direction)
-        val totalCount = countExposureContents()
+        val categoryIds = categoryIds?.takeIf { it.isNotEmpty() }
+        val page = findExploreContentPage(lastSeenOffset, size, sortType, direction, categoryIds)
+        val totalCount =
+            if (categoryIds == null) {
+                countExposureContents()
+            } else {
+                exposureContentService.countByCategoryIds(categoryIds)
+            }
 
         return ExploreContentsResult(
             contents = page.contents,
@@ -35,17 +42,18 @@ class NewsletterExploreService(
         size: Int,
         sortType: ExploreSortType,
         direction: Sort.Direction,
+        categoryIds: List<Long>? = null,
     ): ExploreContentPageResult {
         val fetcher: (Long, Int) -> List<ExploreContentRow> =
             when (sortType) {
-                ExploreSortType.REGISTERED -> { offset: Long, limit: Int ->
-                    exposureContentService.getExploreContentRows(offset, limit, direction)
+                ExploreSortType.REGISTERED -> { offset, limit ->
+                    exposureContentService.getExploreContentRows(offset, limit, direction, categoryIds)
                 }
-                ExploreSortType.PUBLISHED -> { offset: Long, limit: Int ->
-                    exposureContentService.getExploreContentRowsSortedByPublishedAt(offset, limit, direction)
+                ExploreSortType.PUBLISHED -> { offset, limit ->
+                    exposureContentService.getExploreContentRowsSortedByPublishedAt(offset, limit, direction, categoryIds)
                 }
             }
-        return if (lastSeenOffset == FIRST_PAGE_OFFSET) {
+        return if (categoryIds == null && lastSeenOffset == FIRST_PAGE_OFFSET) {
             findCachedFirstExploreContentPage(sortType, direction, size, fetcher)
         } else {
             loadPage(lastSeenOffset, size, fetcher)

--- a/external/src/main/kotlin/com/nexters/external/repository/ExposureContentRepository.kt
+++ b/external/src/main/kotlin/com/nexters/external/repository/ExposureContentRepository.kt
@@ -226,6 +226,174 @@ interface ExposureContentRepository : JpaRepository<ExposureContent, Long> {
 
     @Query(
         """
+        SELECT new com.nexters.external.repository.ExploreContentRow(
+            e.id,
+            c.id,
+            e.provocativeKeyword,
+            e.provocativeHeadline,
+            e.summaryContent,
+            c.originalUrl,
+            c.imageUrl,
+            c.newsletterName,
+            cp.language,
+            e.createdAt,
+            e.updatedAt
+        )
+        FROM ExposureContent e
+        JOIN e.content c
+        LEFT JOIN c.contentProvider cp
+        WHERE EXISTS (
+            SELECT 1 FROM ContentCategoryScore ccs
+            WHERE ccs.contentId = c.id AND ccs.categoryId IN :categoryIds AND ccs.totalScore > 0
+        )
+    """,
+    )
+    fun findExploreRowsByCategoryIds(
+        @Param("categoryIds") categoryIds: List<Long>,
+        pageable: Pageable,
+    ): List<ExploreContentRow>
+
+    @Query(
+        """
+        SELECT new com.nexters.external.repository.ExploreContentRow(
+            e.id,
+            c.id,
+            e.provocativeKeyword,
+            e.provocativeHeadline,
+            e.summaryContent,
+            c.originalUrl,
+            c.imageUrl,
+            c.newsletterName,
+            cp.language,
+            e.createdAt,
+            e.updatedAt
+        )
+        FROM ExposureContent e
+        JOIN e.content c
+        LEFT JOIN c.contentProvider cp
+        WHERE e.id < :lastSeenOffset
+        AND EXISTS (
+            SELECT 1 FROM ContentCategoryScore ccs
+            WHERE ccs.contentId = c.id AND ccs.categoryId IN :categoryIds AND ccs.totalScore > 0
+        )
+    """,
+    )
+    fun findExploreRowsAfterByCategoryIds(
+        @Param("lastSeenOffset") lastSeenOffset: Long,
+        @Param("categoryIds") categoryIds: List<Long>,
+        pageable: Pageable,
+    ): List<ExploreContentRow>
+
+    @Query(
+        """
+        SELECT new com.nexters.external.repository.ExploreContentRow(
+            e.id,
+            c.id,
+            e.provocativeKeyword,
+            e.provocativeHeadline,
+            e.summaryContent,
+            c.originalUrl,
+            c.imageUrl,
+            c.newsletterName,
+            cp.language,
+            e.createdAt,
+            e.updatedAt
+        )
+        FROM ExposureContent e
+        JOIN e.content c
+        LEFT JOIN c.contentProvider cp
+        WHERE e.id > :lastSeenOffset
+        AND EXISTS (
+            SELECT 1 FROM ContentCategoryScore ccs
+            WHERE ccs.contentId = c.id AND ccs.categoryId IN :categoryIds AND ccs.totalScore > 0
+        )
+    """,
+    )
+    fun findExploreRowsAfterAscendingByCategoryIds(
+        @Param("lastSeenOffset") lastSeenOffset: Long,
+        @Param("categoryIds") categoryIds: List<Long>,
+        pageable: Pageable,
+    ): List<ExploreContentRow>
+
+    @Query(
+        """
+        SELECT new com.nexters.external.repository.ExploreContentRow(
+            e.id,
+            c.id,
+            e.provocativeKeyword,
+            e.provocativeHeadline,
+            e.summaryContent,
+            c.originalUrl,
+            c.imageUrl,
+            c.newsletterName,
+            cp.language,
+            e.createdAt,
+            e.updatedAt
+        )
+        FROM ExposureContent e
+        JOIN e.content c
+        LEFT JOIN c.contentProvider cp
+        WHERE c.publishedAt < :lastSeenPublishedAt
+        AND EXISTS (
+            SELECT 1 FROM ContentCategoryScore ccs
+            WHERE ccs.contentId = c.id AND ccs.categoryId IN :categoryIds AND ccs.totalScore > 0
+        )
+    """,
+    )
+    fun findExploreRowsAfterByPublishedAtByCategoryIds(
+        @Param("lastSeenPublishedAt") lastSeenPublishedAt: LocalDate,
+        @Param("categoryIds") categoryIds: List<Long>,
+        pageable: Pageable,
+    ): List<ExploreContentRow>
+
+    @Query(
+        """
+        SELECT new com.nexters.external.repository.ExploreContentRow(
+            e.id,
+            c.id,
+            e.provocativeKeyword,
+            e.provocativeHeadline,
+            e.summaryContent,
+            c.originalUrl,
+            c.imageUrl,
+            c.newsletterName,
+            cp.language,
+            e.createdAt,
+            e.updatedAt
+        )
+        FROM ExposureContent e
+        JOIN e.content c
+        LEFT JOIN c.contentProvider cp
+        WHERE c.publishedAt > :lastSeenPublishedAt
+        AND EXISTS (
+            SELECT 1 FROM ContentCategoryScore ccs
+            WHERE ccs.contentId = c.id AND ccs.categoryId IN :categoryIds AND ccs.totalScore > 0
+        )
+    """,
+    )
+    fun findExploreRowsAfterByPublishedAtAscendingByCategoryIds(
+        @Param("lastSeenPublishedAt") lastSeenPublishedAt: LocalDate,
+        @Param("categoryIds") categoryIds: List<Long>,
+        pageable: Pageable,
+    ): List<ExploreContentRow>
+
+    @Query(
+        """
+        SELECT COUNT(e)
+        FROM ExposureContent e
+        JOIN e.content c
+        WHERE EXISTS (
+            SELECT 1 FROM ContentCategoryScore ccs
+            WHERE ccs.contentId = c.id AND ccs.categoryId IN :categoryIds AND ccs.totalScore > 0
+        )
+    """,
+    )
+    fun countByCategoryIds(
+        @Param("categoryIds") categoryIds: List<Long>,
+    ): Long
+
+    @Query(
+        """
         SELECT c FROM Content c
         WHERE c.id IN (
             SELECT DISTINCT e.content.id FROM ExposureContent e

--- a/external/src/main/kotlin/com/nexters/external/service/ExposureContentService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/ExposureContentService.kt
@@ -132,14 +132,16 @@ class ExposureContentService(
         lastSeenOffset: Long,
         limit: Int,
         direction: Sort.Direction = Sort.Direction.DESC,
+        categoryIds: List<Long>? = null,
     ): List<ExploreContentRow> {
         val pageable = PageRequest.of(0, limit, registeredSort(direction))
-        return if (lastSeenOffset == 0L) {
-            exposureContentRepository.findExploreRows(pageable)
-        } else if (direction.isAscending) {
-            exposureContentRepository.findExploreRowsAfterAscending(lastSeenOffset, pageable)
-        } else {
-            exposureContentRepository.findExploreRowsAfter(lastSeenOffset, pageable)
+        return when {
+            lastSeenOffset == 0L && categoryIds == null -> exposureContentRepository.findExploreRows(pageable)
+            lastSeenOffset == 0L && categoryIds != null -> exposureContentRepository.findExploreRowsByCategoryIds(categoryIds, pageable)
+            direction.isAscending && categoryIds == null -> exposureContentRepository.findExploreRowsAfterAscending(lastSeenOffset, pageable)
+            direction.isAscending && categoryIds != null -> exposureContentRepository.findExploreRowsAfterAscendingByCategoryIds(lastSeenOffset, categoryIds, pageable)
+            categoryIds == null -> exposureContentRepository.findExploreRowsAfter(lastSeenOffset, pageable)
+            else -> exposureContentRepository.findExploreRowsAfterByCategoryIds(lastSeenOffset, categoryIds, pageable)
         }
     }
 
@@ -148,25 +150,29 @@ class ExposureContentService(
         lastSeenOffset: Long,
         limit: Int,
         direction: Sort.Direction = Sort.Direction.DESC,
+        categoryIds: List<Long>? = null,
     ): List<ExploreContentRow> {
         val pageable = PageRequest.of(0, limit, publishedSort(direction))
-        if (lastSeenOffset == 0L) return exposureContentRepository.findExploreRows(pageable)
-        val lastSeen =
+        if (lastSeenOffset == 0L) {
+            return when {
+                categoryIds == null -> exposureContentRepository.findExploreRows(pageable)
+                else -> exposureContentRepository.findExploreRowsByCategoryIds(categoryIds, pageable)
+            }
+        }
+        val publishedAt =
             exposureContentRepository
                 .findById(lastSeenOffset)
                 .orElseThrow { NoSuchElementException("Exposure content not found: $lastSeenOffset") }
-        return if (direction.isAscending) {
-            exposureContentRepository.findExploreRowsAfterByPublishedAtAscending(
-                lastSeen.content.publishedAt,
-                pageable,
-            )
-        } else {
-            exposureContentRepository.findExploreRowsAfterByPublishedAt(
-                lastSeen.content.publishedAt,
-                pageable,
-            )
+                .content.publishedAt
+        return when {
+            direction.isAscending && categoryIds == null -> exposureContentRepository.findExploreRowsAfterByPublishedAtAscending(publishedAt, pageable)
+            direction.isAscending && categoryIds != null -> exposureContentRepository.findExploreRowsAfterByPublishedAtAscendingByCategoryIds(publishedAt, categoryIds, pageable)
+            categoryIds == null -> exposureContentRepository.findExploreRowsAfterByPublishedAt(publishedAt, pageable)
+            else -> exposureContentRepository.findExploreRowsAfterByPublishedAtByCategoryIds(publishedAt, categoryIds, pageable)
         }
     }
+
+    fun countByCategoryIds(categoryIds: List<Long>): Long = exposureContentRepository.countByCategoryIds(categoryIds)
 
     fun getAllExposureContentsPaged(pageable: Pageable): Page<ExposureContent> = exposureContentRepository.findAllPaged(pageable)
 

--- a/external/src/main/kotlin/com/nexters/external/service/ExposureContentService.kt
+++ b/external/src/main/kotlin/com/nexters/external/service/ExposureContentService.kt
@@ -138,8 +138,17 @@ class ExposureContentService(
         return when {
             lastSeenOffset == 0L && categoryIds == null -> exposureContentRepository.findExploreRows(pageable)
             lastSeenOffset == 0L && categoryIds != null -> exposureContentRepository.findExploreRowsByCategoryIds(categoryIds, pageable)
-            direction.isAscending && categoryIds == null -> exposureContentRepository.findExploreRowsAfterAscending(lastSeenOffset, pageable)
-            direction.isAscending && categoryIds != null -> exposureContentRepository.findExploreRowsAfterAscendingByCategoryIds(lastSeenOffset, categoryIds, pageable)
+            direction.isAscending && categoryIds == null ->
+                exposureContentRepository.findExploreRowsAfterAscending(
+                    lastSeenOffset,
+                    pageable
+                )
+            direction.isAscending && categoryIds != null ->
+                exposureContentRepository.findExploreRowsAfterAscendingByCategoryIds(
+                    lastSeenOffset,
+                    categoryIds,
+                    pageable
+                )
             categoryIds == null -> exposureContentRepository.findExploreRowsAfter(lastSeenOffset, pageable)
             else -> exposureContentRepository.findExploreRowsAfterByCategoryIds(lastSeenOffset, categoryIds, pageable)
         }
@@ -165,8 +174,18 @@ class ExposureContentService(
                 .orElseThrow { NoSuchElementException("Exposure content not found: $lastSeenOffset") }
                 .content.publishedAt
         return when {
-            direction.isAscending && categoryIds == null -> exposureContentRepository.findExploreRowsAfterByPublishedAtAscending(publishedAt, pageable)
-            direction.isAscending && categoryIds != null -> exposureContentRepository.findExploreRowsAfterByPublishedAtAscendingByCategoryIds(publishedAt, categoryIds, pageable)
+            direction.isAscending && categoryIds == null ->
+                exposureContentRepository.findExploreRowsAfterByPublishedAtAscending(
+                    publishedAt,
+                    pageable
+                )
+            direction.isAscending && categoryIds != null ->
+                exposureContentRepository
+                    .findExploreRowsAfterByPublishedAtAscendingByCategoryIds(
+                        publishedAt,
+                        categoryIds,
+                        pageable
+                    )
             categoryIds == null -> exposureContentRepository.findExploreRowsAfterByPublishedAt(publishedAt, pageable)
             else -> exposureContentRepository.findExploreRowsAfterByPublishedAtByCategoryIds(publishedAt, categoryIds, pageable)
         }


### PR DESCRIPTION
## 작업 내용
- 탐색 피드에 직군 카테고리 필터링 기능을 추가합니다.
- `GET /api/newsletters/explore/contents`에 `categoryIds` 파라미터 추가
  - `GET /api/newsletters/explore/contents?sort=PUBLISHED&size=20&categoryIds=2&categoryIds=5`
- `content_category_scores` 테이블의 EXISTS 서브쿼리로 필터링
- `categoryIds` 있을 경우 캐시 X